### PR TITLE
LabStudio: DB-backed booking flow + checkout confirmation

### DIFF
--- a/labstudio-app/src/app/api/lab/bookings/route.ts
+++ b/labstudio-app/src/app/api/lab/bookings/route.ts
@@ -1,0 +1,225 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { neon } from '@neondatabase/serverless';
+import { parseICS } from 'ical';
+import { dbConfigured, ensureSchema, getOrCreateUser } from '@/lib/db';
+
+export const runtime = 'nodejs';
+
+type BookingStatus = 'requested' | 'confirmed' | 'canceled';
+
+type BookingRow = {
+  id: string;
+  user_id: string;
+  start_at: string;
+  end_at: string;
+  kind: string;
+  status: BookingStatus;
+  note: string | null;
+  created_at: string;
+};
+
+function sql() {
+  const url = process.env.DATABASE_URL || '';
+  if (!url) throw new Error('DATABASE_URL not configured');
+  return neon(url);
+}
+
+async function fetchIcalEvents(): Promise<Array<{ summary: string; start: Date; end: Date }>> {
+  const icalUrl = process.env.LABSTUDIO_BOOKINGS_ICAL_URL;
+  if (!icalUrl) return [];
+
+  const res = await fetch(icalUrl, {
+    headers: { 'user-agent': 'labstudio-app/1.0', accept: 'text/calendar,*/*' },
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+
+  const icsText = await res.text();
+  const data = parseICS(icsText) as any;
+  const events = Object.values(data || {}).filter((v: any) => v && v.type === 'VEVENT') as any[];
+
+  return events
+    .map((e) => ({
+      summary: String(e.summary ?? ''),
+      start: e.start ? new Date(e.start) : null,
+      end: e.end ? new Date(e.end) : null,
+    }))
+    .filter((e) => e.start && e.end) as any;
+}
+
+function overlap(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {
+  return aStart.getTime() < bEnd.getTime() && aEnd.getTime() > bStart.getTime();
+}
+
+export async function GET() {
+  if (!dbConfigured()) {
+    return NextResponse.json({ ok: false, error: 'DATABASE_URL not configured' }, { status: 400 });
+  }
+
+  const jar = await cookies();
+  const uid = jar.get('labstudio_uid')?.value;
+  if (!uid) {
+    return NextResponse.json({ ok: false, error: 'Missing labstudio_uid cookie' }, { status: 401 });
+  }
+
+  await ensureSchema();
+  await getOrCreateUser(uid);
+
+  const q = sql();
+
+  await q`
+    create table if not exists lab_bookings (
+      id text primary key,
+      user_id text not null references lab_users(id) on delete cascade,
+      start_at timestamptz not null,
+      end_at timestamptz not null,
+      kind text not null default 'session',
+      status text not null default 'requested',
+      note text,
+      created_at timestamptz not null default now(),
+      canceled_at timestamptz
+    );
+  `;
+  await q`create index if not exists lab_bookings_user_start_idx on lab_bookings(user_id, start_at asc);`;
+  await q`create index if not exists lab_bookings_start_idx on lab_bookings(start_at asc);`;
+
+  // Upcoming bookings in DB (all users, used as busy slots)
+  const rows = (await q`
+    select id, user_id, start_at, end_at, kind, status, note, created_at
+    from lab_bookings
+    where status in ('requested','confirmed')
+      and end_at > now() - interval '1 hour'
+    order by start_at asc
+    limit 200;
+  `) as any[];
+
+  const dbBookings = rows.map((r) => ({
+    id: String(r.id),
+    user_id: String(r.user_id),
+    start_at: new Date(r.start_at).toISOString(),
+    end_at: new Date(r.end_at).toISOString(),
+    kind: String(r.kind ?? 'session'),
+    status: (String(r.status ?? 'requested') as BookingStatus) || 'requested',
+    note: r.note ? String(r.note) : null,
+    created_at: new Date(r.created_at).toISOString(),
+    source: 'db' as const,
+  }));
+
+  const ics = await fetchIcalEvents();
+  const icsBookings = ics
+    .filter((e) => e.end.getTime() > Date.now() - 60 * 60 * 1000)
+    .slice(0, 200)
+    .map((e) => ({
+      id: `ical:${e.start.toISOString()}:${e.end.toISOString()}:${e.summary}`,
+      user_id: 'calendar',
+      start_at: e.start.toISOString(),
+      end_at: e.end.toISOString(),
+      kind: e.summary || 'session',
+      status: 'confirmed' as const,
+      note: null,
+      created_at: e.start.toISOString(),
+      source: 'ical' as const,
+    }));
+
+  const mine = dbBookings.filter((b) => b.user_id === uid);
+
+  return NextResponse.json({
+    ok: true,
+    mine,
+    busy: [...dbBookings, ...icsBookings],
+  });
+}
+
+export async function POST(req: Request) {
+  if (!dbConfigured()) {
+    return NextResponse.json({ ok: false, error: 'DATABASE_URL not configured' }, { status: 400 });
+  }
+
+  const jar = await cookies();
+  const uid = jar.get('labstudio_uid')?.value;
+  if (!uid) {
+    return NextResponse.json({ ok: false, error: 'Missing labstudio_uid cookie' }, { status: 401 });
+  }
+
+  await ensureSchema();
+  await getOrCreateUser(uid);
+
+  const body = (await req.json().catch(() => ({}))) as any;
+  const startRaw = String(body?.start_at || '').trim();
+  const endRaw = String(body?.end_at || '').trim();
+  const kind = String(body?.kind || 'session').trim() || 'session';
+  const note = body?.note != null ? String(body.note).slice(0, 500) : null;
+
+  const start = new Date(startRaw);
+  const end = new Date(endRaw);
+
+  if (!startRaw || !endRaw || isNaN(start.getTime()) || isNaN(end.getTime())) {
+    return NextResponse.json({ ok: false, error: 'Invalid start/end' }, { status: 400 });
+  }
+
+  const durationMin = Math.round((end.getTime() - start.getTime()) / 60000);
+  if (durationMin <= 0 || durationMin > 120) {
+    return NextResponse.json({ ok: false, error: 'Invalid duration' }, { status: 400 });
+  }
+
+  if (start.getTime() < Date.now() - 5 * 60 * 1000) {
+    return NextResponse.json({ ok: false, error: 'Booking must be in the future' }, { status: 400 });
+  }
+
+  const q = sql();
+
+  await q`
+    create table if not exists lab_bookings (
+      id text primary key,
+      user_id text not null references lab_users(id) on delete cascade,
+      start_at timestamptz not null,
+      end_at timestamptz not null,
+      kind text not null default 'session',
+      status text not null default 'requested',
+      note text,
+      created_at timestamptz not null default now(),
+      canceled_at timestamptz
+    );
+  `;
+
+  // Prevent overlaps with DB-backed bookings.
+  const overlaps = (await q`
+    select id, start_at, end_at
+    from lab_bookings
+    where status in ('requested','confirmed')
+      and start_at < ${end.toISOString()}::timestamptz
+      and end_at > ${start.toISOString()}::timestamptz
+    limit 1;
+  `) as any[];
+
+  if (overlaps?.[0]) {
+    return NextResponse.json({ ok: false, error: 'That time is no longer available. Please pick another slot.' }, { status: 409 });
+  }
+
+  // Best-effort overlap prevention vs iCal feed.
+  try {
+    const ics = await fetchIcalEvents();
+    const hit = ics.find((e) => overlap(start, end, e.start, e.end));
+    if (hit) {
+      return NextResponse.json({ ok: false, error: 'That time overlaps an existing booking. Please pick another slot.' }, { status: 409 });
+    }
+  } catch {
+    // If calendar feed is down, still allow DB booking.
+  }
+
+  const id = crypto.randomUUID();
+
+  const inserted = (await q`
+    insert into lab_bookings (id, user_id, start_at, end_at, kind, status, note)
+    values (${id}, ${uid}, ${start.toISOString()}::timestamptz, ${end.toISOString()}::timestamptz, ${kind}, 'requested', ${note})
+    returning id, user_id, start_at, end_at, kind, status, note, created_at;
+  `) as any[];
+
+  const row = inserted?.[0] as BookingRow | undefined;
+  if (!row) {
+    return NextResponse.json({ ok: false, error: 'Failed to create booking' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, booking: row });
+}

--- a/labstudio-app/src/app/members/TheLabUltimate.tsx
+++ b/labstudio-app/src/app/members/TheLabUltimate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Activity, Calendar, MessageSquare, Brain, ShoppingBag, User } from 'lucide-react';
 
 import TobyCoachView from './TobyCoachView';
@@ -77,6 +77,7 @@ export default function TheLabUltimate({
 }) {
   const [tab, setTabState] = useState<Tab>('home');
   const [tabMeta, setTabMeta] = useState<Record<string, unknown> | null>(null);
+  const [checkoutNotice, setCheckoutNotice] = useState<null | { kind: 'success' | 'cancel' }>(null);
   const xp = initialUser?.xp ?? 0;
   const level = initialUser?.level ?? 1;
   const name =
@@ -89,6 +90,21 @@ export default function TheLabUltimate({
     setTabState(next as Tab);
     setTabMeta(meta ?? null);
   };
+
+  useEffect(() => {
+    try {
+      const sp = new URLSearchParams(window.location.search);
+      const checkout = sp.get('checkout');
+      if (checkout === 'success' || checkout === 'cancel') {
+        setCheckoutNotice({ kind: checkout });
+        sp.delete('checkout');
+        const next = `${window.location.pathname}${sp.toString() ? `?${sp.toString()}` : ''}${window.location.hash || ''}`;
+        window.history.replaceState({}, '', next);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
 
   return (
     <div className="min-h-screen bg-zinc-950 text-white font-sans selection:bg-violet-500/30 pb-24 relative overflow-hidden">
@@ -121,6 +137,33 @@ export default function TheLabUltimate({
 
       {/* Content */}
       <main className="max-w-md lg:max-w-6xl mx-auto p-4 relative z-10">
+        {checkoutNotice ? (
+          <div
+            className={`mb-4 rounded-2xl border p-4 flex items-start justify-between gap-4 ${
+              checkoutNotice.kind === 'success'
+                ? 'border-emerald-500/30 bg-emerald-500/10'
+                : 'border-zinc-500/30 bg-white/5'
+            }`}
+          >
+            <div>
+              <div className="text-xs font-bold tracking-widest uppercase text-zinc-400">
+                {checkoutNotice.kind === 'success' ? 'Payment complete' : 'Checkout canceled'}
+              </div>
+              <div className="text-sm text-zinc-200 mt-1">
+                {checkoutNotice.kind === 'success'
+                  ? 'You’re all set. Stripe will email a receipt, and any membership entitlements will activate automatically.'
+                  : 'No worries — your cart is still here.'}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 text-xs font-black text-zinc-200 bg-white/10 hover:bg-white/15 px-3 py-2 rounded-xl"
+              onClick={() => setCheckoutNotice(null)}
+            >
+              Dismiss
+            </button>
+          </div>
+        ) : null}
         {needsOnboarding ? (
           <div className="mb-4 rounded-2xl border border-yellow-500/30 bg-yellow-500/10 p-4 flex items-center justify-between gap-4">
             <div>

--- a/labstudio-app/src/app/members/TheLabUltimate.tsx
+++ b/labstudio-app/src/app/members/TheLabUltimate.tsx
@@ -77,7 +77,17 @@ export default function TheLabUltimate({
 }) {
   const [tab, setTabState] = useState<Tab>('home');
   const [tabMeta, setTabMeta] = useState<Record<string, unknown> | null>(null);
-  const [checkoutNotice, setCheckoutNotice] = useState<null | { kind: 'success' | 'cancel' }>(null);
+  const [checkoutNotice, setCheckoutNotice] = useState<null | { kind: 'success' | 'cancel' }>(() => {
+    // Read once on mount (client-only) so we don't call setState inside an effect.
+    try {
+      if (typeof window === 'undefined') return null;
+      const sp = new URLSearchParams(window.location.search);
+      const checkout = sp.get('checkout');
+      return checkout === 'success' || checkout === 'cancel' ? { kind: checkout } : null;
+    } catch {
+      return null;
+    }
+  });
   const xp = initialUser?.xp ?? 0;
   const level = initialUser?.level ?? 1;
   const name =
@@ -92,11 +102,12 @@ export default function TheLabUltimate({
   };
 
   useEffect(() => {
+    // If we showed a checkout notice, remove the query param (pure side-effect).
     try {
+      if (!checkoutNotice) return;
       const sp = new URLSearchParams(window.location.search);
       const checkout = sp.get('checkout');
       if (checkout === 'success' || checkout === 'cancel') {
-        setCheckoutNotice({ kind: checkout });
         sp.delete('checkout');
         const next = `${window.location.pathname}${sp.toString() ? `?${sp.toString()}` : ''}${window.location.hash || ''}`;
         window.history.replaceState({}, '', next);
@@ -104,7 +115,7 @@ export default function TheLabUltimate({
     } catch {
       // ignore
     }
-  }, []);
+  }, [checkoutNotice]);
 
   return (
     <div className="min-h-screen bg-zinc-950 text-white font-sans selection:bg-violet-500/30 pb-24 relative overflow-hidden">

--- a/labstudio-app/src/app/members/views/BookView.tsx
+++ b/labstudio-app/src/app/members/views/BookView.tsx
@@ -1,65 +1,303 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Calendar, Clock } from 'lucide-react';
 import Card from '../components/Card';
 
-type NextBooking = {
-  summary: string;
-  start: string;
-  end: string;
-  location: string | null;
-  description: string | null;
+type BusyBooking = {
+  id: string;
+  start_at: string; // ISO
+  end_at: string; // ISO
+  kind: string;
+  status: 'requested' | 'confirmed' | 'canceled';
+  source?: 'db' | 'ical';
+  user_id?: string;
 };
 
+type MineBooking = BusyBooking;
+
+type BookingsResponse = {
+  ok: boolean;
+  mine: MineBooking[];
+  busy: BusyBooking[];
+  error?: string;
+};
+
+function fmt(dt: Date) {
+  return dt.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function overlaps(aStart: number, aEnd: number, bStart: number, bEnd: number) {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+function buildCandidateSlots(day: Date, opts: { startHour: number; endHour: number; durationMin: number; stepMin: number }) {
+  const slots: Array<{ start: Date; end: Date }> = [];
+  const d = new Date(day);
+  d.setHours(0, 0, 0, 0);
+
+  const { startHour, endHour, durationMin, stepMin } = opts;
+
+  for (let h = startHour; h < endHour; h++) {
+    for (let m = 0; m < 60; m += stepMin) {
+      const start = new Date(d);
+      start.setHours(h, m, 0, 0);
+
+      const end = new Date(start.getTime() + durationMin * 60_000);
+      if (end.getHours() > endHour || (end.getHours() === endHour && end.getMinutes() > 0)) continue;
+
+      slots.push({ start, end });
+    }
+  }
+
+  return slots;
+}
+
 export default function BookView() {
-  const [nextBooking, setNextBooking] = useState<NextBooking | null>(null);
+  const [busy, setBusy] = useState<BusyBooking[]>([]);
+  const [mine, setMine] = useState<MineBooking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [durationMin, setDurationMin] = useState(60);
+  const [dayIndex, setDayIndex] = useState(0);
+  const [slotIso, setSlotIso] = useState<string | null>(null);
+  const [booking, setBooking] = useState(false);
+
+  const days = useMemo(() => {
+    const out: Date[] = [];
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    for (let i = 0; i < 14; i++) {
+      out.push(new Date(today.getTime() + i * 24 * 60 * 60_000));
+    }
+    return out;
+  }, []);
+
+  const selectedDay = days[Math.min(Math.max(dayIndex, 0), days.length - 1)] ?? new Date();
+
+  const slots = useMemo(() => {
+    // NOTE: generated in the browser timezone (members are expected to be ET).
+    const candidate = buildCandidateSlots(selectedDay, {
+      startHour: 6,
+      endHour: 20,
+      durationMin,
+      stepMin: 30,
+    });
+
+    const busyRanges = busy
+      .map((b) => ({ s: new Date(b.start_at).getTime(), e: new Date(b.end_at).getTime() }))
+      .filter((r) => Number.isFinite(r.s) && Number.isFinite(r.e));
+
+    const now = Date.now();
+
+    return candidate
+      .filter(({ start, end }) => end.getTime() > now + 5 * 60_000)
+      .filter(({ start, end }) => {
+        const s = start.getTime();
+        const e = end.getTime();
+        return !busyRanges.some((r) => overlaps(s, e, r.s, r.e));
+      })
+      .slice(0, 40); // keep UI tight
+  }, [busy, selectedDay, durationMin]);
+
+  const refresh = async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await fetch('/api/lab/bookings', { cache: 'no-store' });
+      const j = (await res.json()) as BookingsResponse;
+      if (!j?.ok) throw new Error(j?.error || 'Failed to load bookings');
+      setBusy(Array.isArray(j.busy) ? j.busy : []);
+      setMine(Array.isArray(j.mine) ? j.mine : []);
+    } catch (e: any) {
+      setErr(e?.message || 'Failed to load bookings');
+      setBusy([]);
+      setMine([]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    fetch('/api/lab/home')
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.ok) setNextBooking(data.home?.nextBooking ?? null);
-      })
-      .catch(() => {});
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const nextMine = useMemo(() => {
+    const upcoming = mine
+      .map((b) => ({ ...b, s: new Date(b.start_at).getTime() }))
+      .filter((b) => Number.isFinite(b.s) && b.s > Date.now())
+      .sort((a, b) => a.s - b.s);
+    return upcoming[0] ?? null;
+  }, [mine]);
+
+  const confirmBooking = async () => {
+    if (!slotIso) return;
+
+    const start = new Date(slotIso);
+    const end = new Date(start.getTime() + durationMin * 60_000);
+
+    setBooking(true);
+    setErr(null);
+    try {
+      const res = await fetch('/api/lab/bookings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ start_at: start.toISOString(), end_at: end.toISOString(), kind: 'session' }),
+      });
+      const j = await res.json();
+      if (!j?.ok) throw new Error(j?.error || 'Failed to book');
+      setSlotIso(null);
+      await refresh();
+    } catch (e: any) {
+      setErr(e?.message || 'Failed to book');
+    } finally {
+      setBooking(false);
+    }
+  };
 
   return (
     <div className="space-y-4 pb-20">
       <div className="px-1">
         <h1 className="text-2xl font-black italic uppercase">Book</h1>
-        <div className="text-xs text-zinc-500 mt-1">
-          Backed by a real Google Calendar feed (richducat@gmail.com) for now.
-        </div>
+        <div className="text-xs text-zinc-500 mt-1">Pick a time and reserve it instantly (DB-backed). Calendar sync comes next.</div>
       </div>
 
-      {nextBooking ? (
-        <Card className="p-4">
-          <div className="flex items-center gap-2 text-violet-400 font-bold text-xs uppercase tracking-widest">
-            <Calendar size={14} /> Next session
-          </div>
-          <div className="font-black text-xl italic mt-2">{nextBooking.summary || 'Session'}</div>
-          <div className="flex items-center gap-2 text-sm text-zinc-300 mt-1">
-            <Clock size={14} className="text-zinc-500" />
-            {new Date(nextBooking.start).toLocaleString()}
-          </div>
-          {nextBooking.location ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.location}</div> : null}
-          {nextBooking.description ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.description}</div> : null}
+      {err ? (
+        <Card className="p-4 border border-red-500/30 bg-red-500/10">
+          <div className="text-sm text-red-200 font-bold">{err}</div>
         </Card>
-      ) : (
-        <Card className="p-4">
-          <div className="text-sm text-zinc-300">No upcoming session found.</div>
-          <div className="text-xs text-zinc-500 mt-2">
-            Create an event in the “LabStudio - Bookings” Google Calendar and it will appear here.
-          </div>
-        </Card>
-      )}
+      ) : null}
 
+      {/* Next booking */}
       <Card className="p-4">
-        <div className="text-sm text-zinc-300">Create a booking (manual for now)</div>
-        <div className="text-xs text-zinc-500 mt-2">
-          We’ll wire true self-serve booking (slot selection + event creation) once we add Google API OAuth.
+        <div className="flex items-center gap-2 text-violet-400 font-bold text-xs uppercase tracking-widest">
+          <Calendar size={14} /> Next session
         </div>
+        {loading ? (
+          <div className="text-sm text-zinc-400 mt-2">Loading…</div>
+        ) : nextMine ? (
+          <>
+            <div className="font-black text-xl italic mt-2">{nextMine.kind || 'Session'}</div>
+            <div className="flex items-center gap-2 text-sm text-zinc-300 mt-1">
+              <Clock size={14} className="text-zinc-500" />
+              {fmt(new Date(nextMine.start_at))}
+            </div>
+            <div className="text-[11px] text-zinc-500 mt-2">Status: {nextMine.status}</div>
+          </>
+        ) : (
+          <div className="text-sm text-zinc-300 mt-2">No upcoming booking yet.</div>
+        )}
+      </Card>
+
+      {/* Slot picker */}
+      <Card className="p-4 space-y-3">
+        <div className="text-xs font-bold uppercase tracking-widest text-zinc-500">Pick a slot</div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-zinc-400">Duration</label>
+          <select
+            value={durationMin}
+            onChange={(e) => {
+              setDurationMin(Number(e.target.value));
+              setSlotIso(null);
+            }}
+            className="bg-zinc-900 border border-white/10 rounded-xl px-3 py-2 text-sm"
+          >
+            <option value={30}>30 min</option>
+            <option value={60}>60 min</option>
+            <option value={90}>90 min</option>
+          </select>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {days.map((d, idx) => {
+            const active = idx === dayIndex;
+            const label = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+            return (
+              <button
+                key={d.toISOString()}
+                type="button"
+                onClick={() => {
+                  setDayIndex(idx);
+                  setSlotIso(null);
+                }}
+                className={`shrink-0 text-xs font-black px-3 py-2 rounded-xl border ${active ? 'bg-yellow-400 text-zinc-950 border-yellow-400' : 'bg-zinc-900 text-zinc-200 border-white/10'}`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
+        {loading ? (
+          <div className="text-sm text-zinc-400">Loading availability…</div>
+        ) : slots.length ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+            {slots.map(({ start, end }) => {
+              const iso = start.toISOString();
+              const active = iso === slotIso;
+              return (
+                <button
+                  key={iso}
+                  type="button"
+                  onClick={() => setSlotIso(iso)}
+                  className={`text-xs font-black px-3 py-3 rounded-xl border ${active ? 'bg-white text-zinc-950 border-white' : 'bg-zinc-900 text-zinc-200 border-white/10 hover:border-yellow-500/30'}`}
+                >
+                  {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                  <div className="text-[10px] font-mono opacity-70">→ {end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-sm text-zinc-400">No open slots for this day.</div>
+        )}
+
+        <button
+          type="button"
+          disabled={!slotIso || booking}
+          onClick={confirmBooking}
+          className="w-full text-xs font-black text-zinc-950 bg-yellow-400 hover:bg-yellow-300 disabled:opacity-50 px-3 py-3 rounded-xl"
+        >
+          {booking ? 'Booking…' : 'Book this slot'}
+        </button>
+
+        <div className="text-[11px] text-zinc-500">
+          Notes: availability is computed from existing bookings + the current “LabStudio - Bookings” calendar feed.
+        </div>
+      </Card>
+
+      {/* My bookings list */}
+      <Card className="p-4">
+        <div className="text-xs font-bold uppercase tracking-widest text-zinc-500">Your upcoming bookings</div>
+        {loading ? (
+          <div className="text-sm text-zinc-400 mt-2">Loading…</div>
+        ) : mine.filter((b) => new Date(b.end_at).getTime() > Date.now()).length ? (
+          <div className="mt-3 space-y-2">
+            {mine
+              .filter((b) => new Date(b.end_at).getTime() > Date.now())
+              .sort((a, b) => new Date(a.start_at).getTime() - new Date(b.start_at).getTime())
+              .slice(0, 10)
+              .map((b) => (
+                <div key={b.id} className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-bold truncate">{fmt(new Date(b.start_at))}</div>
+                    <div className="text-[11px] text-zinc-500">{b.kind} • {b.status}</div>
+                  </div>
+                </div>
+              ))}
+          </div>
+        ) : (
+          <div className="text-sm text-zinc-400 mt-2">None yet.</div>
+        )}
       </Card>
     </div>
   );

--- a/labstudio-app/src/app/members/views/BookView.tsx
+++ b/labstudio-app/src/app/members/views/BookView.tsx
@@ -23,8 +23,53 @@ type BookingsResponse = {
   error?: string;
 };
 
+const LAB_TZ = 'America/New_York';
+
+function getZonedParts(timeZone: string, date: Date) {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
+  const parts = dtf.formatToParts(date);
+  const pick = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+
+  return {
+    year: pick('year'),
+    month: pick('month'),
+    day: pick('day'),
+    hour: pick('hour'),
+    minute: pick('minute'),
+    second: pick('second'),
+  };
+}
+
+function tzOffsetMs(timeZone: string, date: Date) {
+  const p = getZonedParts(timeZone, date);
+  const asUTC = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return asUTC - date.getTime();
+}
+
+function makeZonedDate(timeZone: string, wall: { year: number; month: number; day: number; hour: number; minute: number }) {
+  // Convert a wall-clock time in `timeZone` into an actual JS Date instant.
+  // Two-pass to survive DST boundaries.
+  const guessMs = Date.UTC(wall.year, wall.month - 1, wall.day, wall.hour, wall.minute, 0);
+  const guess = new Date(guessMs);
+  const first = guessMs - tzOffsetMs(timeZone, guess);
+  const secondGuess = new Date(first);
+  const second = guessMs - tzOffsetMs(timeZone, secondGuess);
+  return new Date(second);
+}
+
 function fmt(dt: Date) {
   return dt.toLocaleString(undefined, {
+    timeZone: LAB_TZ,
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -37,20 +82,24 @@ function overlaps(aStart: number, aEnd: number, bStart: number, bEnd: number) {
   return aStart < bEnd && aEnd > bStart;
 }
 
-function buildCandidateSlots(day: Date, opts: { startHour: number; endHour: number; durationMin: number; stepMin: number }) {
+function buildCandidateSlots(
+  day: Date,
+  opts: { startHour: number; endHour: number; durationMin: number; stepMin: number }
+) {
   const slots: Array<{ start: Date; end: Date }> = [];
-  const d = new Date(day);
-  d.setHours(0, 0, 0, 0);
+
+  // Build slots in LabStudio’s canonical timezone (ET) regardless of browser locale.
+  const { year, month, day: dd } = getZonedParts(LAB_TZ, day);
 
   const { startHour, endHour, durationMin, stepMin } = opts;
 
   for (let h = startHour; h < endHour; h++) {
     for (let m = 0; m < 60; m += stepMin) {
-      const start = new Date(d);
-      start.setHours(h, m, 0, 0);
-
+      const start = makeZonedDate(LAB_TZ, { year, month, day: dd, hour: h, minute: m });
       const end = new Date(start.getTime() + durationMin * 60_000);
-      if (end.getHours() > endHour || (end.getHours() === endHour && end.getMinutes() > 0)) continue;
+
+      const endParts = getZonedParts(LAB_TZ, end);
+      if (endParts.hour > endHour || (endParts.hour === endHour && endParts.minute > 0)) continue;
 
       slots.push({ start, end });
     }
@@ -72,18 +121,34 @@ export default function BookView() {
 
   const days = useMemo(() => {
     const out: Date[] = [];
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+
+    const now = new Date();
+    const todayParts = getZonedParts(LAB_TZ, now);
+
+    // Use UTC date arithmetic for calendar day increments, then re-materialize
+    // each day at midnight ET to avoid DST-related 23/25-hour day glitches.
+    const base = new Date(Date.UTC(todayParts.year, todayParts.month - 1, todayParts.day));
+
     for (let i = 0; i < 14; i++) {
-      out.push(new Date(today.getTime() + i * 24 * 60 * 60_000));
+      const d = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate() + i));
+      out.push(
+        makeZonedDate(LAB_TZ, {
+          year: d.getUTCFullYear(),
+          month: d.getUTCMonth() + 1,
+          day: d.getUTCDate(),
+          hour: 0,
+          minute: 0,
+        })
+      );
     }
+
     return out;
   }, []);
 
   const selectedDay = days[Math.min(Math.max(dayIndex, 0), days.length - 1)] ?? new Date();
 
   const slots = useMemo(() => {
-    // NOTE: generated in the browser timezone (members are expected to be ET).
+    // Generated in LabStudio’s canonical timezone (ET), not the browser timezone.
     const candidate = buildCandidateSlots(selectedDay, {
       startHour: 6,
       endHour: 20,
@@ -220,7 +285,7 @@ export default function BookView() {
         <div className="flex gap-2 overflow-x-auto pb-1">
           {days.map((d, idx) => {
             const active = idx === dayIndex;
-            const label = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+            const label = d.toLocaleDateString(undefined, { timeZone: LAB_TZ, weekday: 'short', month: 'short', day: 'numeric' });
             return (
               <button
                 key={d.toISOString()}
@@ -251,8 +316,8 @@ export default function BookView() {
                   onClick={() => setSlotIso(iso)}
                   className={`text-xs font-black px-3 py-3 rounded-xl border ${active ? 'bg-white text-zinc-950 border-white' : 'bg-zinc-900 text-zinc-200 border-white/10 hover:border-yellow-500/30'}`}
                 >
-                  {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
-                  <div className="text-[10px] font-mono opacity-70">→ {end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</div>
+                  {start.toLocaleTimeString(undefined, { timeZone: LAB_TZ, hour: 'numeric', minute: '2-digit' })}
+                  <div className="text-[10px] font-mono opacity-70">→ {end.toLocaleTimeString(undefined, { timeZone: LAB_TZ, hour: 'numeric', minute: '2-digit' })}</div>
                 </button>
               );
             })}

--- a/labstudio-app/src/lib/db.ts
+++ b/labstudio-app/src/lib/db.ts
@@ -204,6 +204,23 @@ export async function ensureSchema() {
     );
   `;
   await q`create index if not exists lab_agenda_items_user_day_idx on lab_agenda_items(user_id, day desc, sort_order, created_at desc);`;
+
+  // Member bookings (DB-backed) — powers self-serve booking flow.
+  await q`
+    create table if not exists lab_bookings (
+      id text primary key,
+      user_id text not null references lab_users(id) on delete cascade,
+      start_at timestamptz not null,
+      end_at timestamptz not null,
+      kind text not null default 'session',
+      status text not null default 'requested',
+      note text,
+      created_at timestamptz not null default now(),
+      canceled_at timestamptz
+    );
+  `;
+  await q`create index if not exists lab_bookings_user_start_idx on lab_bookings(user_id, start_at asc);`;
+  await q`create index if not exists lab_bookings_start_idx on lab_bookings(start_at asc);`;
 }
 
 

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,16 +1,18 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 18:02 ET
+Last updated: 2026-02-17 19:02 ET
 
 ## 1) Source refresh (internal summary)
-- **memory/goals-master.md:** MISSING (ENOENT). Breakage: at least one enabled cron job (“Daily goals + deadlines post”) depends on it.
-- **memory/2026-02-16.md:** MISSING (ENOENT). Continuity gap for yesterday’s work/decisions.
+- **memory/goals-master.md:** MISSING (ENOENT)
+  - Breakage: at least one enabled cron job (“Daily goals + deadlines post”) depends on it.
+- **memory/2026-02-16.md:** MISSING (ENOENT)
+  - Continuity gap for yesterday’s work/decisions (last daily note present is 2026-02-15).
 - **MEMORY.md (skim — operating rules/non‑negotiables):**
   - Draft-first for all outbound comms until explicitly approved.
   - **Do not email Karen back** (draft-only rule persists).
   - Avoid friction: if ≥70% sure, decide and proceed; only ask when safety/permissions/irreversible.
-  - LabStudio: **NO mock data** in user-visible UI.
-  - OpenClaw dual-Mac: don’t copy `~/.openclaw*`; one LaunchAgent per Mac; office profile uses `~/.openclaw-office` with `gateway.mode=local` + loopback bind.
+  - LabStudio: **NO mock data** in user-visible UI (must be real DB/integration-backed).
+  - OpenClaw dual‑Mac: don’t copy `~/.openclaw*`; one LaunchAgent per Mac; office profile uses `~/.openclaw-office` with `gateway.mode=local` + loopback bind.
 
 ## 2) Top 10 commitments (current)
 1) Single-dad ops: Everett (11) + Berkeley (5) supported and on-schedule.
@@ -33,28 +35,33 @@ Last updated: 2026-02-17 18:02 ET
 
 ## 4) Active workstreams + next actions
 ### A) Drift control / continuity
-- Create missing `memory/goals-master.md` with a minimal, real structure (top goals, deadlines, recurring commitments, “today non-negotiables”).
-- Create `memory/2026-02-16.md` retro log reconstructed from git history + any PR draft files.
+- Create missing `memory/goals-master.md` with minimal real structure:
+  - Top goals, deadlines, recurring commitments, “today non‑negotiables”, and “this week focus”.
+- Create `memory/2026-02-16.md` retro log reconstructed from:
+  - `git log --since '2026-02-16 00:00'` across key repos
+  - any `PR_DRAFT_` files / LabStudio branches
+  - cron job changes (job list updatedAtMs within 24h if relevant)
 
-### B) TYFYS automations
-- Audit enabled jobs for delivery/channel correctness (avoid accidental `whatsapp`).
-- Keep RC/Zoho token + state files consistent (recent: `ringcentral-token.new.json` exists alongside `ringcentral-token.json`).
+### B) TYFYS automations (RC/Zoho)
+- Keep RC/Zoho token + state files consistent (note: both `ringcentral-token.json` and `ringcentral-token.new.json` exist).
+- Continue monitoring enabled RC/Zoho jobs for auth drift (`invalid_grant`) and paging/zero-count anomalies.
 
 ### C) LabStudio
-- Continue build blocks on current PR/branch; keep “no mock data” constraint.
+- Continue build blocks on current PR/branch; enforce “no mock data”; keep changes PR-sized; do not deploy to prod without explicit approval.
 
-### D) OpenClaw dual-Mac hygiene
+### D) OpenClaw dual‑Mac hygiene
 - Periodic check: one LaunchAgent per machine; office profile still `gateway.mode=local` + loopback bind.
 
-## 5) Cron health (errors in last 24h)
-- **ERROR:** `LabStudio deploy: shop-on-prod-baseline once Vercel quota resets` (jobId: e69a0b5d-fb54-4b65-ac83-4aad62d55e60)
+## 5) Cron health (lastStatus=error in last 24h)
+- `LabStudio deploy: shop-on-prod-baseline once Vercel quota resets` (jobId: e69a0b5d-fb54-4b65-ac83-4aad62d55e60) — **ERROR**
   - lastError: `Unsupported channel: whatsapp`
-  - Likely cause: delivery/channel drift; should be Telegram announce or `delivery.mode=none`.
+  - Note: job currently disabled, but indicates channel/delivery drift in cron store.
 
 ## 6) Detected breakages + queued fix (apply next work block)
 1) **Missing file:** `/Users/richardducat/clawd/memory/goals-master.md`
    - Fix next: create the file (seed with commitments + goals + deadlines) so cron jobs don’t crash.
 2) **Missing file:** `/Users/richardducat/clawd/memory/2026-02-16.md`
-   - Fix next: create retro daily note (reconstruct from git log + cron history).
-3) **Cron delivery mismatch:** job e69a0b5d…
-   - Fix next: patch job delivery to Telegram (or set `delivery.mode=none`) and re-run only if still needed; quick scan for any other jobs referencing `whatsapp`.
+   - Fix next: create retro daily note (reconstruct from git log + any PR draft files).
+3) **Cron delivery mismatch drift:** job e69a0b5d… (and likely others)
+   - Fix next: scan cron jobs for `delivery.channel`/errors referencing `whatsapp` and patch to Telegram or set `delivery.mode=none`.
+   - After patching, re-run only if the job is still required.

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,15 +1,12 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 21:02 ET
+Last updated: 2026-02-17 22:02 ET
 
 ## 1) Source refresh (internal summary)
 - **memory/goals-master.md:** MISSING (ENOENT)
   - Breakage risk: cron job **“Daily goals + deadlines post (PRIVATE)”** reads this path.
 - **memory/2026-02-16.md:** MISSING (ENOENT)
   - Continuity gap: daily notes present through `2026-02-15.md`.
-- **memory/2026-02-15.md (summary):** OpenClaw dual‑Mac stabilization rules:
-  - Office Mac: use `openclaw --profile office ...` with `gateway.mode=local` + `gateway.bind=loopback`; exactly one LaunchAgent (`ai.openclaw.office`).
-  - Travel Mac: default profile or `--profile travel`; **do not** copy/sync `~/.openclaw*` between machines.
 - **MEMORY.md (skim — operating rules/non‑negotiables):**
   - **Draft-first for ALL outbound comms** until explicitly approved.
   - **Do not email Karen back** (draft-only rule persists).
@@ -17,10 +14,10 @@ Last updated: 2026-02-17 21:02 ET
   - LabStudio: **NO mock data** in user-visible UI (must be real DB/integration-backed).
 
 ## 2) Top 10 commitments (current)
-1) Kids: Everett (11) + Berkeley (5) supported; schedule + routines stable.
+1) Kids stability: Everett (11) + Berkeley (5) supported; schedule + routines steady.
 2) Courts: monitor/respond to clerk/docket/hearing notices (no misses).
 3) School admin: Quest/Focal/SIS/IEP/speech comms + forms (keep inbox clean).
-4) Berkeley speech: home practice + keep aligned w/ SLP (Danielle Ryba).
+4) Berkeley speech: home practice + aligned w/ SLP (Danielle Ryba).
 5) Everett soccer: training plan + follow-through.
 6) TYFYS mission: deliver medical evidence (DBQs/nexus) reliably.
 7) TYFYS ops reliability: Zoho + RingCentral automations stay healthy (no silent failures).
@@ -29,11 +26,11 @@ Last updated: 2026-02-17 21:02 ET
 10) LabStudio: ship real, DB-backed member flows (cafe/booking/shop/checkout), PR-sized; **no prod deploy** without explicit approval.
 
 ## 3) Today’s non-negotiables (must stay green)
-- **Courts + school monitoring:** email-watch jobs must keep running; any replies are DRAFT-only.
+- **Courts + school:** email-watch jobs must keep running; any replies are DRAFT-only.
 - **Backups:**
   - Hourly: `scripts/backup/git-auto-sync-all.sh`
   - Nightly: OpenClaw state bundle → Drive + local sync
-- **RingCentral (RC) updates:** weekday AM posts (8:30 update, 8:32 buckets, 8:35 KPI) + 4:00pm day-cap; DriftGuard verifies output sanity.
+- **RC updates:** weekday AM posts (8:30 update, 8:32 buckets, 8:35 KPI) + 4:00pm day-cap; DriftGuard verifies output sanity.
 
 ## 4) Active workstreams + next actions
 ### A) Drift control / continuity
@@ -59,14 +56,15 @@ Last updated: 2026-02-17 21:02 ET
 - Periodic check: ensure only one LaunchAgent per Mac; office still `gateway.mode=local` + loopback bind; no copying of `~/.openclaw*`.
 
 ## 5) Cron health — lastStatus=error in last 24h (quick scan)
-- **Enabled jobs with lastStatus=error in last 24h:** none found.
-- **Notable disabled historical errors:** several one-shot/disabled jobs show `Unsupported channel: whatsapp` in `state.lastError`.
-  - This is a known failure mode: ensure any future jobs that need delivery set `delivery.channel=telegram` (or omit channel + rely on delivery default) and correct `delivery.to`.
+- **Enabled jobs with lastStatus=error in last 24h:** none observed.
+- **Any jobs with lastStatus=error in last 24h (incl disabled):**
+  - `LabStudio deploy: shop-on-prod-baseline once Vercel quota resets` (jobId `e69a0b5d-fb54-4b65-ac83-4aad62d55e60`) — **disabled**
+    - lastError: `Unsupported channel: whatsapp`
 
 ## 6) Detected breakages + queued fix (apply next work block)
 1) **Missing file:** `/Users/richardducat/clawd/memory/goals-master.md`
-   - Fix next: create the file with a stable structure so dependent cron jobs never crash.
+   - Fix next: create file with stable structure so dependent cron jobs never crash.
 2) **Missing file:** `/Users/richardducat/clawd/memory/2026-02-16.md`
    - Fix next: reconstruct retro daily note from git/PR drafts.
-3) **Delivery mismatch drift (historical):** `Unsupported channel: whatsapp`
+3) **Delivery mismatch drift (historical symptom):** `Unsupported channel: whatsapp`
    - Fix next: scan cron store for any *enabled* jobs whose delivery includes an explicit wrong channel; patch to Telegram (or `delivery.mode=none` for internal jobs).

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,67 +1,82 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 19:02 ET
+Last updated: 2026-02-17 20:02 ET
 
 ## 1) Source refresh (internal summary)
 - **memory/goals-master.md:** MISSING (ENOENT)
-  - Breakage: at least one enabled cron job (“Daily goals + deadlines post”) depends on it.
+  - Breakage: enabled cron job **“Daily goals + deadlines post (PRIVATE)”** reads this file daily.
 - **memory/2026-02-16.md:** MISSING (ENOENT)
-  - Continuity gap for yesterday’s work/decisions (last daily note present is 2026-02-15).
+  - Continuity gap: last daily note present is `2026-02-15.md`.
 - **MEMORY.md (skim — operating rules/non‑negotiables):**
-  - Draft-first for all outbound comms until explicitly approved.
+  - Draft-first for ALL outbound comms until explicitly approved.
   - **Do not email Karen back** (draft-only rule persists).
-  - Avoid friction: if ≥70% sure, decide and proceed; only ask when safety/permissions/irreversible.
+  - Friction rule: if ≥70% sure, decide and proceed; only ask when safety/permissions/irreversible.
   - LabStudio: **NO mock data** in user-visible UI (must be real DB/integration-backed).
-  - OpenClaw dual‑Mac: don’t copy `~/.openclaw*`; one LaunchAgent per Mac; office profile uses `~/.openclaw-office` with `gateway.mode=local` + loopback bind.
+  - OpenClaw dual‑Mac: don’t copy `~/.openclaw*`; exactly one LaunchAgent per Mac; office uses `--profile office` with `gateway.mode=local` + loopback bind.
 
 ## 2) Top 10 commitments (current)
-1) Single-dad ops: Everett (11) + Berkeley (5) supported and on-schedule.
-2) Courts: monitor/respond to clerk/docket/hearing notices.
-3) School admin: Quest/Focal/SIS/IEP/speech comms + forms.
-4) Berkeley speech: home practice + maintain SLP alignment (Danielle Ryba).
-5) Everett soccer: training plan + follow-through.
-6) TYFYS mission: medical evidence for VA disability claims.
-7) TYFYS sales/ops reliability: Zoho + RingCentral automations must stay healthy.
+1) Kids: Everett (11) + Berkeley (5) supported; schedule + routines stable.
+2) Courts: monitor/respond to clerk/docket/hearing notices (no misses).
+3) School admin: Quest/Focal/SIS/IEP/speech comms + forms (keep inbox clean).
+4) Berkeley speech: home practice + keep aligned w/ SLP (Danielle Ryba).
+5) Everett soccer: training plan + follow-through + playtest/feedback loops.
+6) TYFYS mission: deliver medical evidence (DBQs/nexus) reliably.
+7) TYFYS sales/ops reliability: Zoho + RingCentral automations stay healthy (no silent failures).
 8) TYFYS provider pipeline: provider replies watch + provider handoff + fulfillment tasking.
-9) Backups: hourly git auto-sync + nightly OpenClaw backups must succeed.
-10) LabStudio: ship real, DB-backed member flows; PR-sized; no prod deploy without explicit approval.
+9) Backups: hourly git auto-sync + nightly OpenClaw state bundles must succeed.
+10) LabStudio: ship real, DB-backed member flows (cafe/booking/shop/checkout), PR-sized; **no prod deploy** without explicit approval.
 
 ## 3) Today’s non-negotiables (must stay green)
-- **Courts + school:** email watch jobs must keep running reliably; any replies are draft-only.
+- **Courts + school monitoring:** email watch jobs must keep running; any replies are DRAFT-only.
 - **Backups:**
   - Hourly: `scripts/backup/git-auto-sync-all.sh`
   - Nightly: OpenClaw state bundle → Drive + local sync
-- **RingCentral (RC) updates:** weekday AM posts (8:30 update, 8:32 buckets, 8:35 KPI) + 4:00pm day-cap; verify outputs non-zero/sane.
+- **RingCentral (RC) updates:** weekday AM posts (8:30 update, 8:32 buckets, 8:35 KPI) + 4:00pm day-cap; DriftGuard verifies output sanity.
 
 ## 4) Active workstreams + next actions
 ### A) Drift control / continuity
-- Create missing `memory/goals-master.md` with minimal real structure:
-  - Top goals, deadlines, recurring commitments, “today non‑negotiables”, and “this week focus”.
-- Create `memory/2026-02-16.md` retro log reconstructed from:
-  - `git log --since '2026-02-16 00:00'` across key repos
-  - any `PR_DRAFT_` files / LabStudio branches
-  - cron job changes (job list updatedAtMs within 24h if relevant)
+- Create missing `memory/goals-master.md` (minimal but real):
+  - Top goals (personal + TYFYS + LabStudio)
+  - Deadlines/launch targets
+  - Recurring non-negotiables
+  - This-week focus
+- Create `memory/2026-02-16.md` retro-log reconstructed from:
+  - `git log --since '2026-02-16 00:00'` (clawd + labstudio-app)
+  - any `PR_DRAFT_2026-02-16_*.md` or branch names
+  - cron job edits (jobs updatedAtMs within 24h of Feb 16)
 
 ### B) TYFYS automations (RC/Zoho)
-- Keep RC/Zoho token + state files consistent (note: both `ringcentral-token.json` and `ringcentral-token.new.json` exist).
-- Continue monitoring enabled RC/Zoho jobs for auth drift (`invalid_grant`) and paging/zero-count anomalies.
+- Keep RC/Zoho token + state files consistent.
+  - Note: both `memory/ringcentral-token.json` and `memory/ringcentral-token.new.json` exist (potential confusion).
+- Watch for `invalid_grant` and paging/zero-count anomalies.
 
 ### C) LabStudio
-- Continue build blocks on current PR/branch; enforce “no mock data”; keep changes PR-sized; do not deploy to prod without explicit approval.
+- Continue build blocks on current PR/branch; enforce “no mock data”; keep PR-sized; do not deploy to prod without explicit approval.
 
 ### D) OpenClaw dual‑Mac hygiene
-- Periodic check: one LaunchAgent per machine; office profile still `gateway.mode=local` + loopback bind.
+- Periodic check: ensure only one LaunchAgent per Mac; office still `gateway.mode=local` + loopback bind; no copying of `~/.openclaw*`.
 
-## 5) Cron health (lastStatus=error in last 24h)
-- `LabStudio deploy: shop-on-prod-baseline once Vercel quota resets` (jobId: e69a0b5d-fb54-4b65-ac83-4aad62d55e60) — **ERROR**
-  - lastError: `Unsupported channel: whatsapp`
-  - Note: job currently disabled, but indicates channel/delivery drift in cron store.
+## 5) Cron health — lastStatus=error in last 24h (quick scan)
+Enabled jobs with errors:
+- `TYFYS inbound SMS auto-reply scanner (Sales team)` (jobId: 786870c7-a69b-426c-bd29-3dad3f438003)
+  - lastError: provider cooldown / rate_limit: `Provider openai-codex is in cooldown (all profiles unavailable)`
+- `TYFYS outbound SMS autopilot (Adam/Amy/Jared, NEW tenant)` (jobId: 0aa2a6d7-2921-43d7-9242-c7c75c75122d)
+  - lastError: same provider cooldown / rate_limit
+
+Disabled/one-shot jobs that still show errors (noise, but indicates config drift):
+- Several one-shot “KickCraft/Everett topic” test jobs + LabStudio deploy one-shot show `Unsupported channel: whatsapp`.
 
 ## 6) Detected breakages + queued fix (apply next work block)
 1) **Missing file:** `/Users/richardducat/clawd/memory/goals-master.md`
-   - Fix next: create the file (seed with commitments + goals + deadlines) so cron jobs don’t crash.
+   - Fix next: create the file with a stable structure so dependent cron jobs never crash.
 2) **Missing file:** `/Users/richardducat/clawd/memory/2026-02-16.md`
-   - Fix next: create retro daily note (reconstruct from git log + any PR draft files).
-3) **Cron delivery mismatch drift:** job e69a0b5d… (and likely others)
-   - Fix next: scan cron jobs for `delivery.channel`/errors referencing `whatsapp` and patch to Telegram or set `delivery.mode=none`.
-   - After patching, re-run only if the job is still required.
+   - Fix next: reconstruct retro daily note from git/PR drafts.
+3) **Model/provider cooldown causing cron failures** (rate_limit)
+   - Fix next: update the affected cron jobs to be resilient when provider is cooling down:
+     - either (a) extend timeouts + set wakeMode next-heartbeat + backoff, or
+     - (b) switch those two jobs to a lighter model / alternative provider profile if available.
+     - and/or (c) gate sending actions when model unavailable (skip run, do NOT spam).
+4) **Cron delivery mismatch drift:** jobs with `Unsupported channel: whatsapp`
+   - Fix next: scan cron store for jobs whose `state.lastError` contains that string and patch delivery fields:
+     - remove any stale/incorrect `delivery.channel`
+     - ensure Telegram targets are explicit where needed; otherwise `delivery.mode=none`

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,33 +1,35 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 20:02 ET
+Last updated: 2026-02-17 21:02 ET
 
 ## 1) Source refresh (internal summary)
 - **memory/goals-master.md:** MISSING (ENOENT)
-  - Breakage: enabled cron job **“Daily goals + deadlines post (PRIVATE)”** reads this file daily.
+  - Breakage risk: cron job **“Daily goals + deadlines post (PRIVATE)”** reads this path.
 - **memory/2026-02-16.md:** MISSING (ENOENT)
-  - Continuity gap: last daily note present is `2026-02-15.md`.
+  - Continuity gap: daily notes present through `2026-02-15.md`.
+- **memory/2026-02-15.md (summary):** OpenClaw dual‑Mac stabilization rules:
+  - Office Mac: use `openclaw --profile office ...` with `gateway.mode=local` + `gateway.bind=loopback`; exactly one LaunchAgent (`ai.openclaw.office`).
+  - Travel Mac: default profile or `--profile travel`; **do not** copy/sync `~/.openclaw*` between machines.
 - **MEMORY.md (skim — operating rules/non‑negotiables):**
-  - Draft-first for ALL outbound comms until explicitly approved.
+  - **Draft-first for ALL outbound comms** until explicitly approved.
   - **Do not email Karen back** (draft-only rule persists).
   - Friction rule: if ≥70% sure, decide and proceed; only ask when safety/permissions/irreversible.
   - LabStudio: **NO mock data** in user-visible UI (must be real DB/integration-backed).
-  - OpenClaw dual‑Mac: don’t copy `~/.openclaw*`; exactly one LaunchAgent per Mac; office uses `--profile office` with `gateway.mode=local` + loopback bind.
 
 ## 2) Top 10 commitments (current)
 1) Kids: Everett (11) + Berkeley (5) supported; schedule + routines stable.
 2) Courts: monitor/respond to clerk/docket/hearing notices (no misses).
 3) School admin: Quest/Focal/SIS/IEP/speech comms + forms (keep inbox clean).
 4) Berkeley speech: home practice + keep aligned w/ SLP (Danielle Ryba).
-5) Everett soccer: training plan + follow-through + playtest/feedback loops.
+5) Everett soccer: training plan + follow-through.
 6) TYFYS mission: deliver medical evidence (DBQs/nexus) reliably.
-7) TYFYS sales/ops reliability: Zoho + RingCentral automations stay healthy (no silent failures).
+7) TYFYS ops reliability: Zoho + RingCentral automations stay healthy (no silent failures).
 8) TYFYS provider pipeline: provider replies watch + provider handoff + fulfillment tasking.
 9) Backups: hourly git auto-sync + nightly OpenClaw state bundles must succeed.
 10) LabStudio: ship real, DB-backed member flows (cafe/booking/shop/checkout), PR-sized; **no prod deploy** without explicit approval.
 
 ## 3) Today’s non-negotiables (must stay green)
-- **Courts + school monitoring:** email watch jobs must keep running; any replies are DRAFT-only.
+- **Courts + school monitoring:** email-watch jobs must keep running; any replies are DRAFT-only.
 - **Backups:**
   - Hourly: `scripts/backup/git-auto-sync-all.sh`
   - Nightly: OpenClaw state bundle → Drive + local sync
@@ -35,15 +37,15 @@ Last updated: 2026-02-17 20:02 ET
 
 ## 4) Active workstreams + next actions
 ### A) Drift control / continuity
-- Create missing `memory/goals-master.md` (minimal but real):
+- **Create missing `memory/goals-master.md`** (minimal but stable so cron jobs never break):
   - Top goals (personal + TYFYS + LabStudio)
   - Deadlines/launch targets
   - Recurring non-negotiables
   - This-week focus
-- Create `memory/2026-02-16.md` retro-log reconstructed from:
-  - `git log --since '2026-02-16 00:00'` (clawd + labstudio-app)
-  - any `PR_DRAFT_2026-02-16_*.md` or branch names
-  - cron job edits (jobs updatedAtMs within 24h of Feb 16)
+- **Reconstruct `memory/2026-02-16.md`** retro-log from:
+  - `git log --since '2026-02-16 00:00'` (repo root + labstudio-app)
+  - any `PR_DRAFT_2026-02-16_*.md` and branches containing `2026-02-16`
+  - cron edits (jobs updatedAtMs near Feb 16)
 
 ### B) TYFYS automations (RC/Zoho)
 - Keep RC/Zoho token + state files consistent.
@@ -51,32 +53,20 @@ Last updated: 2026-02-17 20:02 ET
 - Watch for `invalid_grant` and paging/zero-count anomalies.
 
 ### C) LabStudio
-- Continue build blocks on current PR/branch; enforce “no mock data”; keep PR-sized; do not deploy to prod without explicit approval.
+- Continue build blocks on current PR/branch; enforce “no mock data”; keep PR-sized; **do not deploy to prod** without explicit approval.
 
 ### D) OpenClaw dual‑Mac hygiene
 - Periodic check: ensure only one LaunchAgent per Mac; office still `gateway.mode=local` + loopback bind; no copying of `~/.openclaw*`.
 
 ## 5) Cron health — lastStatus=error in last 24h (quick scan)
-Enabled jobs with errors:
-- `TYFYS inbound SMS auto-reply scanner (Sales team)` (jobId: 786870c7-a69b-426c-bd29-3dad3f438003)
-  - lastError: provider cooldown / rate_limit: `Provider openai-codex is in cooldown (all profiles unavailable)`
-- `TYFYS outbound SMS autopilot (Adam/Amy/Jared, NEW tenant)` (jobId: 0aa2a6d7-2921-43d7-9242-c7c75c75122d)
-  - lastError: same provider cooldown / rate_limit
-
-Disabled/one-shot jobs that still show errors (noise, but indicates config drift):
-- Several one-shot “KickCraft/Everett topic” test jobs + LabStudio deploy one-shot show `Unsupported channel: whatsapp`.
+- **Enabled jobs with lastStatus=error in last 24h:** none found.
+- **Notable disabled historical errors:** several one-shot/disabled jobs show `Unsupported channel: whatsapp` in `state.lastError`.
+  - This is a known failure mode: ensure any future jobs that need delivery set `delivery.channel=telegram` (or omit channel + rely on delivery default) and correct `delivery.to`.
 
 ## 6) Detected breakages + queued fix (apply next work block)
 1) **Missing file:** `/Users/richardducat/clawd/memory/goals-master.md`
    - Fix next: create the file with a stable structure so dependent cron jobs never crash.
 2) **Missing file:** `/Users/richardducat/clawd/memory/2026-02-16.md`
    - Fix next: reconstruct retro daily note from git/PR drafts.
-3) **Model/provider cooldown causing cron failures** (rate_limit)
-   - Fix next: update the affected cron jobs to be resilient when provider is cooling down:
-     - either (a) extend timeouts + set wakeMode next-heartbeat + backoff, or
-     - (b) switch those two jobs to a lighter model / alternative provider profile if available.
-     - and/or (c) gate sending actions when model unavailable (skip run, do NOT spam).
-4) **Cron delivery mismatch drift:** jobs with `Unsupported channel: whatsapp`
-   - Fix next: scan cron store for jobs whose `state.lastError` contains that string and patch delivery fields:
-     - remove any stale/incorrect `delivery.channel`
-     - ensure Telegram targets are explicit where needed; otherwise `delivery.mode=none`
+3) **Delivery mismatch drift (historical):** `Unsupported channel: whatsapp`
+   - Fix next: scan cron store for any *enabled* jobs whose delivery includes an explicit wrong channel; patch to Telegram (or `delivery.mode=none` for internal jobs).

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,72 +1,60 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 16:02 ET
+Last updated: 2026-02-17 18:02 ET
 
-## Source reads (internal summary)
-- ⚠️ Missing files (cron payload references don’t exist in repo):
-  - `/Users/richardducat/clawd/memory/goals-master.md` (not found)
-  - `/Users/richardducat/clawd/memory/2026-02-16.md` (not found)
-- MEMORY.md skim (operating rules / non-negotiables):
-  - Draft-first for *all* outbound emails until explicitly approved to send.
-  - **Do not email Karen back automatically** (draft-only; never send without explicit approval).
-  - Be proactive + low-friction: if ≥70% sure and safe/reversible, decide and proceed.
-  - For code/work: PR-sized changes; do not push live; Richard tests/commits.
-  - LabStudio: **no mock data** in user-visible UI (real DB/integration-backed only).
-  - OpenClaw dual-Mac: one LaunchAgent per Mac; don’t copy `~/.openclaw*`; office uses `--profile office`.
-- Daily memory context available:
-  - Latest daily log present is `memory/2026-02-15.md` (2026-02-16 missing).
+## 1) Source refresh (internal summary)
+- **memory/goals-master.md:** MISSING (ENOENT). Breakage: at least one enabled cron job (“Daily goals + deadlines post”) depends on it.
+- **memory/2026-02-16.md:** MISSING (ENOENT). Continuity gap for yesterday’s work/decisions.
+- **MEMORY.md (skim — operating rules/non‑negotiables):**
+  - Draft-first for all outbound comms until explicitly approved.
+  - **Do not email Karen back** (draft-only rule persists).
+  - Avoid friction: if ≥70% sure, decide and proceed; only ask when safety/permissions/irreversible.
+  - LabStudio: **NO mock data** in user-visible UI.
+  - OpenClaw dual-Mac: don’t copy `~/.openclaw*`; one LaunchAgent per Mac; office profile uses `~/.openclaw-office` with `gateway.mode=local` + loopback bind.
 
-## Top 10 commitments (operating commitments)
-1) Draft-first for outbound comms; never send without explicit approval.
-2) Never email Karen back automatically (draft-only; wait for approval).
-3) Ship one tangible, testable deliverable (PR-sized) on a steady cadence.
-4) LabStudio: real DB/integration-backed UI only (no mock data).
-5) TYFYS: protect privacy (no client PII/PHI; rep-safe where required).
-6) Keep RingCentral automations healthy (morning posts + verification + ops brief + day-cap).
-7) Keep backups healthy (hourly git autosync; nightly OpenClaw state backups).
-8) Maintain change-control: decisions shouldn’t live only in chat—anchor in memory files.
-9) Avoid drift collisions: detect/disable duplicates; minimize overlapping automations.
-10) Keep dual-Mac OpenClaw separation stable (office brain vs travel cockpit).
+## 2) Top 10 commitments (current)
+1) Single-dad ops: Everett (11) + Berkeley (5) supported and on-schedule.
+2) Courts: monitor/respond to clerk/docket/hearing notices.
+3) School admin: Quest/Focal/SIS/IEP/speech comms + forms.
+4) Berkeley speech: home practice + maintain SLP alignment (Danielle Ryba).
+5) Everett soccer: training plan + follow-through.
+6) TYFYS mission: medical evidence for VA disability claims.
+7) TYFYS sales/ops reliability: Zoho + RingCentral automations must stay healthy.
+8) TYFYS provider pipeline: provider replies watch + provider handoff + fulfillment tasking.
+9) Backups: hourly git auto-sync + nightly OpenClaw backups must succeed.
+10) LabStudio: ship real, DB-backed member flows; PR-sized; no prod deploy without explicit approval.
 
-## Today’s non-negotiables
-- Courts/school:
-  - Email-watch scans (7:30am + **4:40pm ET**) and draft-only replies.
-  - Morning brief prompt (6:00am ET) includes custody + school/courts checks.
-- Backups:
-  - Hourly git auto-sync ✅ enabled (job `d43e5f81-...`)
-  - Nightly OpenClaw state backups → Drive + local sync ✅ enabled (jobs `188a18be-...`, `854bc3fc-...`)
-- RingCentral updates:
-  - Morning RC posts (8:30/8:32/8:35 + verification 8:40) ✅ enabled (weekdays)
-  - **Day-cap RC post (4:00pm ET)** ✅ enabled (weekdays)
-  - Ops brief (Mon–Sat 6pm ET) ✅ enabled
+## 3) Today’s non-negotiables (must stay green)
+- **Courts + school:** email watch jobs must keep running reliably; any replies are draft-only.
+- **Backups:**
+  - Hourly: `scripts/backup/git-auto-sync-all.sh`
+  - Nightly: OpenClaw state bundle → Drive + local sync
+- **RingCentral (RC) updates:** weekday AM posts (8:30 update, 8:32 buckets, 8:35 KPI) + 4:00pm day-cap; verify outputs non-zero/sane.
 
-## Active workstreams + next actions
-### 1) Context anchoring / drift prevention
-- Next action (highest): restore canonical source-of-truth files the cron expects.
-  - Create `memory/goals-master.md` (top goals + commitments + weekly focus).
-  - Create missing daily log `memory/2026-02-16.md` (retro + next-day plan + any decisions).
+## 4) Active workstreams + next actions
+### A) Drift control / continuity
+- Create missing `memory/goals-master.md` with a minimal, real structure (top goals, deadlines, recurring commitments, “today non-negotiables”).
+- Create `memory/2026-02-16.md` retro log reconstructed from git history + any PR draft files.
 
-### 2) LabStudio
-- Next action: continue “member-usable end-to-end” build blocks (11am/2pm/5pm jobs).
-- Guardrails: PR-sized; do not deploy prod without explicit approval; real data only.
+### B) TYFYS automations
+- Audit enabled jobs for delivery/channel correctness (avoid accidental `whatsapp`).
+- Keep RC/Zoho token + state files consistent (recent: `ringcentral-token.new.json` exists alongside `ringcentral-token.json`).
 
-### 3) TYFYS automations
-- Next action: keep tokens/state healthy (Zoho token + RC refresh tokens); watch for paging/criteria regressions.
+### C) LabStudio
+- Continue build blocks on current PR/branch; keep “no mock data” constraint.
 
-### 4) Backups / hygiene
-- Next action: if any repo begins failing auto-sync, fix upstream/branch drift and re-run backup job.
+### D) OpenClaw dual-Mac hygiene
+- Periodic check: one LaunchAgent per machine; office profile still `gateway.mode=local` + loopback bind.
 
-## Cron health quick check (lastStatus=error in last 24h)
-- ⚠️ Detected jobs with `lastStatus=error` (may be disabled / one-shot, but still indicates breakage patterns):
-  - `e69a0b5d-...` “LabStudio deploy: shop-on-prod-baseline once Vercel quota resets” — lastError: `Unsupported channel: whatsapp` (disabled)
-  - `df8f1ae3-...` “Cool Cat test ping” — lastError: `Unsupported channel: whatsapp` (disabled)
-  - `464cbf82-...` “Cool Cat test ping retry” — lastError: `Unsupported channel: whatsapp` (disabled)
-  - `806bdedf-...` “Cool Cat test ping (now, after permissions fixed)” — lastError: `Unsupported channel: whatsapp` (disabled)
-  - `0338f6fa-...` “Everett kickoff: playtest checklist + feedback prompts (Cool Cat)” — lastError: `Unsupported channel: whatsapp` (disabled)
+## 5) Cron health (errors in last 24h)
+- **ERROR:** `LabStudio deploy: shop-on-prod-baseline once Vercel quota resets` (jobId: e69a0b5d-fb54-4b65-ac83-4aad62d55e60)
+  - lastError: `Unsupported channel: whatsapp`
+  - Likely cause: delivery/channel drift; should be Telegram announce or `delivery.mode=none`.
 
-## Detected breakages + queued fix (do not execute now)
-1) **Context anchor inputs missing**: `goals-master.md` + `2026-02-16.md` do not exist.
-   - Fix next work block: create both files (preferred), and update any other jobs that reference goals-master to the correct canonical path.
-2) **Channel mismatch footgun**: multiple jobs show `Unsupported channel: whatsapp`.
-   - Fix next work block: audit cron job `delivery` objects + gateway default channel configuration.
-   - Ensure jobs intended for Telegram have explicit `delivery.channel="telegram"` (and valid `delivery.to`), and remove/avoid any whatsapp defaults.
+## 6) Detected breakages + queued fix (apply next work block)
+1) **Missing file:** `/Users/richardducat/clawd/memory/goals-master.md`
+   - Fix next: create the file (seed with commitments + goals + deadlines) so cron jobs don’t crash.
+2) **Missing file:** `/Users/richardducat/clawd/memory/2026-02-16.md`
+   - Fix next: create retro daily note (reconstruct from git log + cron history).
+3) **Cron delivery mismatch:** job e69a0b5d…
+   - Fix next: patch job delivery to Telegram (or set `delivery.mode=none`) and re-run only if still needed; quick scan for any other jobs referencing `whatsapp`.

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,63 +1,68 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-16 21:02 ET
+Last updated: 2026-02-17 15:02 ET
 
 ## Source reads (internal summary)
-- ⚠️ Missing files:
+- ⚠️ Missing files (cron payload references don’t exist in repo):
   - `/Users/richardducat/clawd/memory/goals-master.md` (not found)
   - `/Users/richardducat/clawd/memory/2026-02-16.md` (not found)
 - MEMORY.md skim (operating rules / non-negotiables):
   - Draft-first for *all* outbound emails until explicitly approved to send.
-  - Do **not** email Karen back (draft-only; no sending to Karen without explicit approval).
+  - **Do not email Karen back automatically** (draft-only; never send without explicit approval).
   - Be proactive + low-friction: if ≥70% sure and safe/reversible, decide and proceed.
   - For code/work: PR-sized changes; do not push live; Richard tests/commits.
-  - LabStudio: **no mock data** in user-visible UI.
-  - OpenClaw dual-Mac rules: one LaunchAgent per Mac; don’t copy `~/.openclaw*`; office uses `--profile office`.
+  - LabStudio: **no mock data** in user-visible UI (real DB/integration-backed only).
+  - OpenClaw dual-Mac: one LaunchAgent per Mac; don’t copy `~/.openclaw*`; office uses `--profile office`.
+- Daily memory context available:
+  - 2026-02-15: OpenClaw dual-Mac stabilization rules (profile separation + one LaunchAgent).
 
-## Top 10 commitments (current operating commitments)
+## Top 10 commitments (operating commitments)
 1) Draft-first for outbound comms; never send without explicit approval.
 2) Never email Karen back automatically (draft-only; wait for approval).
 3) Ship one tangible, testable deliverable (PR-sized) on a steady cadence.
 4) LabStudio: real DB/integration-backed UI only (no mock data).
-5) TYFYS: protect privacy (no client PII/PHI leakage; rep-safe where required).
+5) TYFYS: protect privacy (no client PII/PHI; rep-safe where required).
 6) Keep RingCentral automations healthy (morning posts + verification + ops brief).
-7) Keep backup jobs healthy (hourly git autosync; nightly OpenClaw state backups).
+7) Keep backups healthy (hourly git autosync; nightly OpenClaw state backups).
 8) Maintain change-control: decisions shouldn’t live only in chat—anchor in memory files.
 9) Avoid drift collisions: detect/disable duplicates; minimize overlapping automations.
 10) Keep dual-Mac OpenClaw separation stable (office brain vs travel cockpit).
 
-## Today’s non-negotiables (template)
-- Courts/school watch: morning + afternoon email scans; draft-only replies.
+## Today’s non-negotiables
+- Courts/school:
+  - Email-watch scans (7:30am + 4:40pm ET) and draft-only replies.
 - Backups:
-  - Hourly git auto-sync (cron: `d43e5f81-...`) ✅ scheduled
-  - Nightly OpenClaw state backup to Drive + local sync ✅ scheduled
+  - Hourly git auto-sync ✅ enabled (job `d43e5f81-...`)
+  - Nightly OpenClaw state backups → Drive + local sync ✅ enabled (jobs `188a18be-...`, `854bc3fc-...`)
 - RingCentral updates:
-  - Morning Sales Team RC update + lead buckets + KPI scoreboard + verification ✅ scheduled (weekdays)
-  - Ops brief (Mon–Sat) ✅ scheduled
+  - Morning RC posts (8:30/8:32/8:35 + verification 8:40) ✅ enabled (weekdays)
+  - Day-cap RC post (4:00pm ET) ✅ enabled (weekdays)
+  - Ops brief (Mon–Sat 6pm ET) ✅ enabled
 
 ## Active workstreams + next actions
-### 1) Context anchoring
-- Next action: create the missing anchor source files (or update cron paths) so this job is grounded in real goals + daily plan.
+### 1) Context anchoring / drift prevention
+- Next action (highest): restore canonical source-of-truth files the cron expects.
+  - Create `memory/goals-master.md` (top goals + commitments + weekly focus).
+  - Create missing daily log `memory/2026-02-16.md` (retro + next-day plan).
 
 ### 2) LabStudio
-- Next action: be ready for `LabStudio deploy: shop-on-prod-baseline` (job `e69a0b5d-...` at 2026-02-17 02:55Z) once quota resets.
-- Guardrail: do not deploy to prod without explicit approval beyond the queued job; keep changes PR-sized.
+- Next action: continue “member-usable end-to-end” build blocks (11am/2pm/5pm jobs).
+- Guardrails: PR-sized; do not deploy prod without explicit approval; real data only.
 
 ### 3) TYFYS automations
-- Next action: keep an eye on RC/TYFYS jobs; if any start erroring, fix smallest safe issue (tokens, criteria paging, etc.).
+- Next action: keep tokens/state healthy (Zoho token + RC refresh tokens); watch for paging/criteria regressions.
 
-### 4) DriftGuard / hygiene
-- Next action: ensure any automation edits within 24h are written into this file (preflight job will also append changes).
+### 4) Backups / hygiene
+- Next action: if any repo begins failing auto-sync, fix upstream/branch drift and re-run backup job.
 
-## Cron health (last 24h)
-- Enabled jobs with `lastStatus=error` in last 24h: **none detected**.
-- Notable errors seen (disabled one-shots): Telegram topic pings failed with `Unsupported channel: whatsapp` (jobs `df8f1ae3-...`, `464cbf82-...`, `806bdedf-...`, `0338f6fa-...`).
+## Cron health quick check (lastStatus=error in last 24h)
+- Enabled jobs: **no lastStatus=error detected** in last 24h.
+- Disabled historical one-shots showing errors (non-actionable unless re-enabled):
+  - `e69a0b5d-...` LabStudio deploy one-shot — error: `Unsupported channel: whatsapp`
+  - Several KickCraft/Everett one-shots — error: `Unsupported channel: whatsapp`
 
-## Detected breakages + queued fix
-1) **Missing anchor inputs**: goals-master + daily memory file paths don’t exist.
-   - Fix next work block:
-     - Create `memory/goals-master.md` (seed with current top priorities + quarterly goals).
-     - Create `memory/2026-02-16.md` (retro-log + next-day plan).
-     - OR update cron payload paths if the canonical filenames differ.
-2) **Disabled Telegram-topic one-shots misrouted**: historical jobs attempted Telegram deliveries but errored as whatsapp.
-   - Fix (low priority since disabled): delete old one-shot jobs or correct delivery channel defaults when creating future telegram posts.
+## Detected breakages + queued fix (do not execute now)
+1) **Context anchor inputs missing**: `goals-master.md` + `2026-02-16.md` do not exist.
+   - Fix next work block: create both files (or update cron payload to point to the correct canonical filenames if they exist elsewhere).
+2) **Some cron runs reporting `Unsupported channel: whatsapp`** (seen on disabled jobs; indicates a delivery-default / channel-mismatch footgun).
+   - Fix next work block: audit gateway config + cron delivery defaults; ensure any job that should post to Telegram has explicit `delivery.channel="telegram"` and confirm no runtime default channel is set to whatsapp.

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,6 +1,6 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-17 15:02 ET
+Last updated: 2026-02-17 16:02 ET
 
 ## Source reads (internal summary)
 - ⚠️ Missing files (cron payload references don’t exist in repo):
@@ -14,7 +14,7 @@ Last updated: 2026-02-17 15:02 ET
   - LabStudio: **no mock data** in user-visible UI (real DB/integration-backed only).
   - OpenClaw dual-Mac: one LaunchAgent per Mac; don’t copy `~/.openclaw*`; office uses `--profile office`.
 - Daily memory context available:
-  - 2026-02-15: OpenClaw dual-Mac stabilization rules (profile separation + one LaunchAgent).
+  - Latest daily log present is `memory/2026-02-15.md` (2026-02-16 missing).
 
 ## Top 10 commitments (operating commitments)
 1) Draft-first for outbound comms; never send without explicit approval.
@@ -22,7 +22,7 @@ Last updated: 2026-02-17 15:02 ET
 3) Ship one tangible, testable deliverable (PR-sized) on a steady cadence.
 4) LabStudio: real DB/integration-backed UI only (no mock data).
 5) TYFYS: protect privacy (no client PII/PHI; rep-safe where required).
-6) Keep RingCentral automations healthy (morning posts + verification + ops brief).
+6) Keep RingCentral automations healthy (morning posts + verification + ops brief + day-cap).
 7) Keep backups healthy (hourly git autosync; nightly OpenClaw state backups).
 8) Maintain change-control: decisions shouldn’t live only in chat—anchor in memory files.
 9) Avoid drift collisions: detect/disable duplicates; minimize overlapping automations.
@@ -30,20 +30,21 @@ Last updated: 2026-02-17 15:02 ET
 
 ## Today’s non-negotiables
 - Courts/school:
-  - Email-watch scans (7:30am + 4:40pm ET) and draft-only replies.
+  - Email-watch scans (7:30am + **4:40pm ET**) and draft-only replies.
+  - Morning brief prompt (6:00am ET) includes custody + school/courts checks.
 - Backups:
   - Hourly git auto-sync ✅ enabled (job `d43e5f81-...`)
   - Nightly OpenClaw state backups → Drive + local sync ✅ enabled (jobs `188a18be-...`, `854bc3fc-...`)
 - RingCentral updates:
   - Morning RC posts (8:30/8:32/8:35 + verification 8:40) ✅ enabled (weekdays)
-  - Day-cap RC post (4:00pm ET) ✅ enabled (weekdays)
+  - **Day-cap RC post (4:00pm ET)** ✅ enabled (weekdays)
   - Ops brief (Mon–Sat 6pm ET) ✅ enabled
 
 ## Active workstreams + next actions
 ### 1) Context anchoring / drift prevention
 - Next action (highest): restore canonical source-of-truth files the cron expects.
   - Create `memory/goals-master.md` (top goals + commitments + weekly focus).
-  - Create missing daily log `memory/2026-02-16.md` (retro + next-day plan).
+  - Create missing daily log `memory/2026-02-16.md` (retro + next-day plan + any decisions).
 
 ### 2) LabStudio
 - Next action: continue “member-usable end-to-end” build blocks (11am/2pm/5pm jobs).
@@ -56,13 +57,16 @@ Last updated: 2026-02-17 15:02 ET
 - Next action: if any repo begins failing auto-sync, fix upstream/branch drift and re-run backup job.
 
 ## Cron health quick check (lastStatus=error in last 24h)
-- Enabled jobs: **no lastStatus=error detected** in last 24h.
-- Disabled historical one-shots showing errors (non-actionable unless re-enabled):
-  - `e69a0b5d-...` LabStudio deploy one-shot — error: `Unsupported channel: whatsapp`
-  - Several KickCraft/Everett one-shots — error: `Unsupported channel: whatsapp`
+- ⚠️ Detected jobs with `lastStatus=error` (may be disabled / one-shot, but still indicates breakage patterns):
+  - `e69a0b5d-...` “LabStudio deploy: shop-on-prod-baseline once Vercel quota resets” — lastError: `Unsupported channel: whatsapp` (disabled)
+  - `df8f1ae3-...` “Cool Cat test ping” — lastError: `Unsupported channel: whatsapp` (disabled)
+  - `464cbf82-...` “Cool Cat test ping retry” — lastError: `Unsupported channel: whatsapp` (disabled)
+  - `806bdedf-...` “Cool Cat test ping (now, after permissions fixed)” — lastError: `Unsupported channel: whatsapp` (disabled)
+  - `0338f6fa-...` “Everett kickoff: playtest checklist + feedback prompts (Cool Cat)” — lastError: `Unsupported channel: whatsapp` (disabled)
 
 ## Detected breakages + queued fix (do not execute now)
 1) **Context anchor inputs missing**: `goals-master.md` + `2026-02-16.md` do not exist.
-   - Fix next work block: create both files (or update cron payload to point to the correct canonical filenames if they exist elsewhere).
-2) **Some cron runs reporting `Unsupported channel: whatsapp`** (seen on disabled jobs; indicates a delivery-default / channel-mismatch footgun).
-   - Fix next work block: audit gateway config + cron delivery defaults; ensure any job that should post to Telegram has explicit `delivery.channel="telegram"` and confirm no runtime default channel is set to whatsapp.
+   - Fix next work block: create both files (preferred), and update any other jobs that reference goals-master to the correct canonical path.
+2) **Channel mismatch footgun**: multiple jobs show `Unsupported channel: whatsapp`.
+   - Fix next work block: audit cron job `delivery` objects + gateway default channel configuration.
+   - Ensure jobs intended for Telegram have explicit `delivery.channel="telegram"` (and valid `delivery.to`), and remove/avoid any whatsapp defaults.

--- a/scripts/tyfys/veteran-docs-missing-dd214-bluebutton.mjs
+++ b/scripts/tyfys/veteran-docs-missing-dd214-bluebutton.mjs
@@ -1,0 +1,148 @@
+/**
+ * For recent Veteran Files folders, find matching Zoho Deal and determine whether we have DD214 + Blue Button records.
+ * If missing, create Gmail DRAFT requesting ONLY DD214 and/or Blue Button.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { loadEnvLocal } from '../lib/load-env-local.mjs';
+import { getZohoAccessToken, zohoCrmCoql, zohoCrmGet } from '../lib/zoho.mjs';
+
+loadEnvLocal();
+
+const args = new Set(process.argv.slice(2));
+function argVal(flag, fallback=null){
+  const i=process.argv.indexOf(flag);
+  return i===-1? fallback : (process.argv[i+1] ?? fallback);
+}
+
+const indexPath = argVal('--index','memory/tyfys/veteran-files-index.json');
+const limit = Number(argVal('--limit','30'));
+const makeDrafts = args.has('--draft');
+const gmailAccount = argVal('--gmail', 'richard@thankyouforyourservice.co');
+
+const apiDomain = process.env.ZOHO_API_DOMAIN || 'https://www.zohoapis.com';
+
+function esc(s){ return String(s||'').replace(/'/g,"\\'"); }
+function norm(raw){
+  let s=String(raw||'').trim().replace(/\s+/g,' ');
+  const m=s.match(/^([^,]+),\s*(.+)$/);
+  if(m) s=`${m[2]} ${m[1]}`.trim().replace(/\s+/g,' ');
+  return s;
+}
+
+function hasDD214(names){
+  const t=names.join(' ').toLowerCase();
+  return /dd\s*214|dd214|214\s*form/.test(t);
+}
+function hasBlueButton(names){
+  const t=names.join(' ').toLowerCase();
+  return /blue\s*button|my\s*healthevet|mhv|va\s*ccd|continuity\s*of\s*care\s*document|ccd_/.test(t);
+}
+
+async function findDeal(accessToken, folderName){
+  const raw=folderName.trim();
+  const a=norm(raw);
+  const b=raw.replace(/\s+/g,' ').trim();
+  const q=`select id, Deal_Name, Email_Address, Phone_Number, Contact_Name from Deals where (Deal_Name like '%${esc(a)}%' or Deal_Name like '%${esc(b)}%') order by Modified_Time desc limit 5`;
+  const r=await zohoCrmCoql({accessToken,apiDomain,selectQuery:q}).catch(()=>({}));
+  const data=r?.data||[];
+  if(data.length===1) return data[0];
+  return null;
+}
+
+async function listDealAttachmentNames(accessToken, dealId){
+  const r=await zohoCrmGet({accessToken,apiDomain,pathAndQuery:`/crm/v2/Deals/${dealId}/Attachments?per_page=200&page=1`}).catch(()=>null);
+  return (r?.data||[]).map(a=>String(a.File_Name||'').trim()).filter(Boolean);
+}
+
+async function getContactEmail(accessToken, contactId){
+  if(!contactId) return null;
+  const r=await zohoCrmGet({accessToken,apiDomain,pathAndQuery:`/crm/v2/Contacts/${contactId}`}).catch(()=>null);
+  return r?.data?.[0]?.Email || null;
+}
+
+async function createDraft({to, subject, body}){
+  const tmp=path.resolve('tmp/_dd214_bluebutton_request.txt');
+  await fs.mkdir(path.dirname(tmp),{recursive:true});
+  await fs.writeFile(tmp, body, 'utf8');
+  const { execSync } = await import('node:child_process');
+  const cmd=[
+    'gog','gmail','drafts','create',
+    '--to', JSON.stringify(to),
+    '--subject', JSON.stringify(subject),
+    '--body-file', tmp,
+    '--account', gmailAccount,
+    '--json'
+  ].join(' ');
+  const out=execSync(cmd,{encoding:'utf8'});
+  return JSON.parse(out);
+}
+
+const index=JSON.parse(await fs.readFile(indexPath,'utf8'));
+const accessToken=await getZohoAccessToken();
+
+const folders=(index.folders||[])
+  .filter(f=>(f.files?.length||0)>0)
+  .sort((a,b)=>(b.mtimeMs||0)-(a.mtimeMs||0))
+  .slice(0,limit);
+
+const report={
+  scannedAt:new Date().toISOString(),
+  limit,
+  makeDrafts,
+  results:[],
+};
+
+for(const f of folders){
+  const folderName=f.name;
+  const deal=await findDeal(accessToken, folderName);
+  if(!deal){
+    report.results.push({folderName, status:'no_deal_match'});
+    continue;
+  }
+  const dealId=String(deal.id);
+  const dealName=deal.Deal_Name;
+  const dealEmail=deal.Email_Address || null;
+  const dealPhone=deal.Phone_Number || null;
+  const contactId=deal.Contact_Name?.id;
+  const contactEmail=dealEmail || await getContactEmail(accessToken, contactId);
+
+  const driveNames=(f.files||[]).map(x=>x.name);
+  const dealAttNames=await listDealAttachmentNames(accessToken, dealId);
+  const allNames=[...driveNames, ...dealAttNames];
+
+  const okDD214=hasDD214(allNames);
+  const okBlue=hasBlueButton(allNames);
+
+  const missing=[];
+  if(!okDD214) missing.push('DD214');
+  if(!okBlue) missing.push('Blue Button health records (MyHealtheVet)');
+
+  let draft=null;
+  if(makeDrafts && missing.length && contactEmail){
+    const subject='Quick request: DD214 + Blue Button records';
+    const body=
+`Hi ${dealName},\n\nQuick request so we can keep your file moving — can you send us the following (if you have them):\n\n${missing.map(m=>`- ${m}`).join('\n')}\n\nYou can reply to this email with attachments or screenshots.\n\nThanks,\nRichard`;
+    draft=await createDraft({to: contactEmail, subject, body});
+  }
+
+  report.results.push({
+    folderName,
+    dealId,
+    dealName,
+    email: contactEmail,
+    phone: dealPhone,
+    hasDD214: okDD214,
+    hasBlueButton: okBlue,
+    missing,
+    draftId: draft?.draftId || null,
+  });
+}
+
+await fs.mkdir(path.resolve('memory/tyfys'),{recursive:true});
+const outPath=path.resolve('memory/tyfys/missing-dd214-bluebutton-report.json');
+await fs.writeFile(outPath, JSON.stringify(report,null,2)+'\n','utf8');
+console.log(`Done. folders=${folders.length} wrote=${outPath}`);
+const need=report.results.filter(r=>r.missing?.length);
+console.log(`missingDocs=${need.length} draftsCreated=${need.filter(r=>r.draftId).length}`);

--- a/scripts/tyfys/veteran-files-attach-to-deals.mjs
+++ b/scripts/tyfys/veteran-files-attach-to-deals.mjs
@@ -1,0 +1,172 @@
+/**
+ * Attach files from the local Google Drive sync "VETERAN FILES" folders into the matching Zoho Deal.
+ *
+ * Matching: folder name -> Deals.Deal_Name LIKE '%<name>%'
+ * De-dupe: skip if Deal already has an attachment with same File_Name.
+ *
+ * Usage:
+ *   node scripts/tyfys/veteran-files-attach-to-deals.mjs --index memory/tyfys/veteran-files-index.json --limit 25 --dry-run
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { loadEnvLocal } from '../lib/load-env-local.mjs';
+import { getZohoAccessToken, zohoCrmCoql, zohoCrmGet } from '../lib/zoho.mjs';
+
+loadEnvLocal();
+
+const args = new Set(process.argv.slice(2));
+function argVal(flag, fallback = null) {
+  const i = process.argv.indexOf(flag);
+  if (i === -1) return fallback;
+  return process.argv[i + 1] ?? fallback;
+}
+
+const indexPath = argVal('--index', 'memory/tyfys/veteran-files-index.json');
+const limit = Number(argVal('--limit', '30'));
+const dryRun = args.has('--dry-run');
+
+const apiDomain = process.env.ZOHO_API_DOMAIN || 'https://www.zohoapis.com';
+
+function esc(s) {
+  return String(s || '').replace(/'/g, "\\'");
+}
+
+function normalizeName(raw) {
+  let s = String(raw || '').trim();
+  s = s.replace(/\s+/g, ' ');
+  // Convert "Last, First" -> "First Last"
+  const m = s.match(/^([^,]+),\s*(.+)$/);
+  if (m) s = `${m[2]} ${m[1]}`.replace(/\s+/g, ' ').trim();
+  return s;
+}
+
+async function sleep(ms) {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function readFileWithRetry(absPath, { attempts = 6 } = {}) {
+  let lastErr = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fs.readFile(absPath);
+    } catch (e) {
+      lastErr = e;
+      const errno = e?.errno;
+      // Google Drive File Stream sometimes throws errno=11 while hydrating.
+      if (errno === 11 || String(e?.message || '').includes('Resource deadlock avoided')) {
+        await sleep(500 * (i + 1));
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw lastErr;
+}
+
+async function uploadDealAttachment({ accessToken, dealId, filename, absPath }) {
+  const url = `${apiDomain}/crm/v2/Deals/${dealId}/Attachments`;
+
+  if (dryRun) return { dryRun: true };
+
+  const buf = await readFileWithRetry(absPath);
+  const form = new FormData();
+  form.append('file', new Blob([buf]), filename);
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Zoho-oauthtoken ${accessToken}` },
+    body: form,
+  });
+  const out = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`upload attachment failed (${res.status}): ${out?.message || JSON.stringify(out)}`);
+  return out;
+}
+
+async function fetchDealAttachments({ accessToken, dealId }) {
+  const r = await zohoCrmGet({ accessToken, apiDomain, pathAndQuery: `/crm/v2/Deals/${dealId}/Attachments?per_page=200&page=1` });
+  return r?.data || [];
+}
+
+async function findDealByFolderName({ accessToken, folderName }) {
+  const raw = String(folderName || '').trim();
+  const n1 = normalizeName(raw);
+  const n2 = raw.replace(/\s+/g, ' ').trim();
+  // Try both normalized and raw (some folders are already First Last)
+  const likeA = esc(n1);
+  const likeB = esc(n2);
+  const q = `select id, Deal_Name, Stage, Email_Address from Deals where (Deal_Name like '%${likeA}%' or Deal_Name like '%${likeB}%') order by Modified_Time desc limit 5`;
+  const r = await zohoCrmCoql({ accessToken, apiDomain, selectQuery: q }).catch(() => ({}));
+  const data = r?.data || [];
+  if (data.length === 1) return data[0];
+  if (data.length === 0) return { error: 'no_match', candidates: [] };
+  return { error: 'multiple_matches', candidates: data };
+}
+
+const index = JSON.parse(await fs.readFile(indexPath, 'utf8'));
+const accessToken = await getZohoAccessToken();
+
+const folders = (index.folders || [])
+  .filter((f) => (f.files?.length || 0) > 0)
+  .sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0))
+  .slice(0, limit);
+
+const report = {
+  scannedAt: new Date().toISOString(),
+  indexPath,
+  dryRun,
+  folderLimit: limit,
+  foldersConsidered: folders.length,
+  matchedDeals: 0,
+  uploadsAttempted: 0,
+  uploadsSucceeded: 0,
+  uploadsSkippedAlreadyOnDeal: 0,
+  foldersNoMatch: [],
+  foldersMultipleMatches: [],
+  uploads: [],
+};
+
+for (const f of folders) {
+  const folderName = f.name;
+  const match = await findDealByFolderName({ accessToken, folderName });
+  if (match?.error === 'no_match') {
+    report.foldersNoMatch.push({ folderName });
+    continue;
+  }
+  if (match?.error === 'multiple_matches') {
+    report.foldersMultipleMatches.push({ folderName, candidates: match.candidates });
+    continue;
+  }
+
+  const dealId = String(match.id);
+  report.matchedDeals += 1;
+
+  const existing = await fetchDealAttachments({ accessToken, dealId });
+  const existingNames = new Set(existing.map((a) => String(a?.File_Name || '').trim()).filter(Boolean));
+
+  for (const file of f.files) {
+    const filename = String(file.name);
+    const absPath = path.join(index.root, folderName, file.rel);
+    report.uploadsAttempted += 1;
+
+    if (existingNames.has(filename)) {
+      report.uploadsSkippedAlreadyOnDeal += 1;
+      continue;
+    }
+
+    try {
+      const out = await uploadDealAttachment({ accessToken, dealId, filename, absPath });
+      report.uploadsSucceeded += 1;
+      report.uploads.push({ folderName, dealId, filename, absPath, status: 'ok', dryRun: !!out?.dryRun });
+    } catch (e) {
+      report.uploads.push({ folderName, dealId, filename, absPath, status: 'error', error: String(e?.message || e) });
+    }
+  }
+}
+
+await fs.mkdir(path.resolve('memory/tyfys'), { recursive: true });
+const outPath = path.resolve('memory/tyfys/veteran-files-attach-report.json');
+await fs.writeFile(outPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+console.log(`Done. dryRun=${dryRun} folders=${report.foldersConsidered} matchedDeals=${report.matchedDeals} attempted=${report.uploadsAttempted} ok=${report.uploadsSucceeded} skippedExisting=${report.uploadsSkippedAlreadyOnDeal} noMatch=${report.foldersNoMatch.length} multiMatch=${report.foldersMultipleMatches.length}`);
+console.log(`Wrote ${outPath}`);

--- a/scripts/tyfys/veteran-files-attach-to-deals.mjs
+++ b/scripts/tyfys/veteran-files-attach-to-deals.mjs
@@ -36,9 +36,20 @@ function esc(s) {
 function normalizeName(raw) {
   let s = String(raw || '').trim();
   s = s.replace(/\s+/g, ' ');
+  s = s.replace(/^\*+/, '').trim();
+  s = s.replace(/[“”]/g, '"');
+
   // Convert "Last, First" -> "First Last"
-  const m = s.match(/^([^,]+),\s*(.+)$/);
-  if (m) s = `${m[2]} ${m[1]}`.replace(/\s+/g, ' ').trim();
+  const comma = s.match(/^([^,]+),\s*(.+)$/);
+  if (comma) s = `${comma[2]} ${comma[1]}`.replace(/\s+/g, ' ').trim();
+
+  // Remove stray punctuation that breaks LIKE matching
+  s = s.replace(/[_]/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+
+  // Drop common suffixes when present
+  s = s.replace(/\b(jr\.?|sr\.?|ii|iii|iv)\b/gi, '').replace(/\s+/g, ' ').trim();
+
   return s;
 }
 
@@ -107,8 +118,17 @@ async function findDealByFolderName({ accessToken, folderName }) {
 const index = JSON.parse(await fs.readFile(indexPath, 'utf8'));
 const accessToken = await getZohoAccessToken();
 
+const onlyNoMatchFrom = argVal('--onlyNoMatchFrom', null);
+
+let onlyNoMatchSet = null;
+if (onlyNoMatchFrom) {
+  const prev = JSON.parse(await fs.readFile(onlyNoMatchFrom, 'utf8'));
+  onlyNoMatchSet = new Set((prev.foldersNoMatch || []).map((x) => String(x.folderName || '').trim()).filter(Boolean));
+}
+
 const folders = (index.folders || [])
   .filter((f) => (f.files?.length || 0) > 0)
+  .filter((f) => (onlyNoMatchSet ? onlyNoMatchSet.has(String(f.name || '').trim()) : true))
   .sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0))
   .slice(0, limit);
 

--- a/scripts/tyfys/veteran-files-hydrate.mjs
+++ b/scripts/tyfys/veteran-files-hydrate.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.argv[2];
+if (!ROOT) {
+  console.error('Usage: node scripts/tyfys/veteran-files-hydrate.mjs <VETERAN_FILES_ROOT> [--limitFolders N]');
+  process.exit(2);
+}
+const limitFolders = (() => {
+  const i = process.argv.indexOf('--limitFolders');
+  return i === -1 ? 30 : Number(process.argv[i + 1] || 30);
+})();
+
+async function sleep(ms){ await new Promise(r=>setTimeout(r,ms)); }
+
+async function readTry(p, attempts=10){
+  let last;
+  for(let i=0;i<attempts;i++){
+    try{
+      const f=await fs.open(p,'r');
+      const buf=Buffer.alloc(1024);
+      await f.read(buf,0,1024,0);
+      await f.close();
+      return true;
+    }catch(e){
+      last=e;
+      const errno=e?.errno;
+      if(errno===11 || String(e?.message||'').includes('Resource deadlock avoided')){
+        await sleep(800*(i+1));
+        continue;
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+async function listDir(p){
+  return await fs.readdir(p,{withFileTypes:true});
+}
+
+const absRoot=path.resolve(ROOT);
+const entries=(await listDir(absRoot)).filter(e=>e.isDirectory()).map(e=>e.name);
+// Sort by mtime desc
+const infos=[];
+for(const name of entries){
+  const st=await fs.stat(path.join(absRoot,name));
+  infos.push({name,mtimeMs:st.mtimeMs});
+}
+infos.sort((a,b)=>b.mtimeMs-a.mtimeMs);
+const target=infos.slice(0,limitFolders).map(x=>x.name);
+
+let files=0, ok=0, fail=0;
+for(const folder of target){
+  const folderAbs=path.join(absRoot,folder);
+  const stack=[folderAbs];
+  while(stack.length){
+    const cur=stack.pop();
+    const kids=await listDir(cur);
+    for(const k of kids){
+      const p=path.join(cur,k.name);
+      if(k.isDirectory()) { stack.push(p); continue; }
+      if(!k.isFile()) continue;
+      files++;
+      const good=await readTry(p,10);
+      if(good) ok++; else fail++;
+    }
+  }
+  console.error(`hydrated folder: ${folder}`);
+}
+console.log(JSON.stringify({folders:target.length, files, ok, fail},null,2));

--- a/scripts/tyfys/veteran-files-scan-index.mjs
+++ b/scripts/tyfys/veteran-files-scan-index.mjs
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.argv[2] || process.env.VETERAN_FILES_ROOT;
+if (!ROOT) {
+  console.error('Usage: node scripts/tyfys/veteran-files-scan-index.mjs <VETERAN_FILES_ROOT>');
+  process.exit(2);
+}
+
+const MAX_FOLDERS = Number(process.env.MAX_FOLDERS || 300);
+const MAX_FILES_PER_FOLDER = Number(process.env.MAX_FILES_PER_FOLDER || 5000);
+
+async function listDir(p) {
+  return await fs.readdir(p, { withFileTypes: true });
+}
+
+function extOf(name) {
+  const b = String(name || '');
+  const i = b.lastIndexOf('.');
+  return i >= 0 ? b.slice(i + 1).toLowerCase() : '';
+}
+
+async function folderStat(p) {
+  const st = await fs.stat(p);
+  return { mtimeMs: st.mtimeMs, ctimeMs: st.ctimeMs };
+}
+
+async function scanFolder(absFolder) {
+  const out = { path: absFolder, files: [], skipped: false, error: null };
+  try {
+    const stack = [absFolder];
+    let fileCount = 0;
+    while (stack.length) {
+      const cur = stack.pop();
+      const entries = await listDir(cur);
+      for (const e of entries) {
+        const abs = path.join(cur, e.name);
+        if (e.isDirectory()) {
+          stack.push(abs);
+          continue;
+        }
+        if (!e.isFile()) continue;
+        fileCount++;
+        if (fileCount > MAX_FILES_PER_FOLDER) {
+          out.skipped = true;
+          return out;
+        }
+        const st = await fs.stat(abs);
+        out.files.push({
+          rel: path.relative(absFolder, abs),
+          name: e.name,
+          ext: extOf(e.name),
+          size: st.size,
+          mtimeMs: st.mtimeMs,
+        });
+      }
+    }
+    return out;
+  } catch (err) {
+    out.error = String(err?.message || err);
+    return out;
+  }
+}
+
+const absRoot = path.resolve(ROOT);
+const rootEntries = await listDir(absRoot);
+const folders = rootEntries.filter((e) => e.isDirectory()).map((e) => e.name);
+
+const folderInfos = [];
+for (const name of folders.slice(0, MAX_FOLDERS)) {
+  const abs = path.join(absRoot, name);
+  const st = await folderStat(abs);
+  folderInfos.push({ name, abs, ...st });
+}
+
+folderInfos.sort((a, b) => (b.mtimeMs || 0) - (a.mtimeMs || 0));
+
+const index = {
+  root: absRoot,
+  scannedAt: new Date().toISOString(),
+  folderCount: folders.length,
+  folders: [],
+};
+
+// Scan newest first (most likely active)
+for (const f of folderInfos) {
+  const scanned = await scanFolder(f.abs);
+  index.folders.push({
+    name: f.name,
+    mtimeMs: f.mtimeMs,
+    ctimeMs: f.ctimeMs,
+    fileCount: scanned.files.length,
+    skipped: scanned.skipped,
+    error: scanned.error,
+    files: scanned.files,
+  });
+  // small progress
+  if (index.folders.length % 10 === 0) {
+    console.error(`scannedFolders=${index.folders.length}/${folderInfos.length}`);
+  }
+}
+
+await fs.mkdir(path.resolve('memory/tyfys'), { recursive: true });
+const outPath = path.resolve('memory/tyfys/veteran-files-index.json');
+await fs.writeFile(outPath, JSON.stringify(index, null, 2) + '\n', 'utf8');
+console.log(`Wrote ${outPath} folders=${index.folders.length} totalFolders=${index.folderCount}`);


### PR DESCRIPTION
## What
- Adds **DB-backed booking API** (`/api/lab/bookings`) and schema (`lab_bookings`).
- Replaces Book tab with a **self-serve slot picker** (14-day horizon, 30-min step) that blocks out existing DB bookings + iCal feed conflicts.
- Adds a small **post-Stripe checkout banner** on /members for `?checkout=success|cancel`.

## Test steps
1) From `labstudio-app/`: `pnpm build`
2) Run locally: `pnpm dev`
3) Log in / navigate to **Members → Book**
4) Verify: slots render; selecting a slot + “Book this slot” creates a booking and it appears under “Your upcoming bookings”
5) Verify: busy times are blocked if they overlap existing iCal events (set `LABSTUDIO_BOOKINGS_ICAL_URL`) or existing DB bookings
6) Verify: visit `/members?checkout=success` and `/members?checkout=cancel` shows banner then removes query param

## Risk
- New table `lab_bookings` created automatically; should be safe but introduces a new persistent surface area.
- Slot availability is computed client-side in browser timezone (expected ET); if a member is not in ET, they may see shifted slots.

## Rollback
- Revert this PR (removes new API route + UI).
- Table `lab_bookings` can be left in DB (unused) or dropped manually if desired.