### PR TITLE
LabStudio: booking requests + cafe checkout schema

### DIFF
--- a/labstudio-app/src/app/api/lab/bookings/_schema.ts
+++ b/labstudio-app/src/app/api/lab/bookings/_schema.ts
@@ -33,9 +33,17 @@ export async function ensureBookingSchema() {
       time_label text not null, -- HH:MM (local ET)
       duration_min integer not null default 60,
       status text not null default 'requested',
-      note text,
-      unique(day, time_label)
+      note text
     );
+  `;
+
+  // Legacy table definitions used a table-level unique(day, time_label) constraint.
+  // Drop it so cancelled bookings can be rebooked, then enforce uniqueness for active slots only.
+  await q`alter table lab_bookings drop constraint if exists lab_bookings_day_time_label_key;`;
+  await q`
+    create unique index if not exists lab_bookings_active_slot_uniq
+      on lab_bookings(day, time_label)
+      where status <> 'cancelled';
   `;
 
   await q`create index if not exists lab_bookings_user_day_idx on lab_bookings(user_id, day desc, time_label);`;

--- a/labstudio-app/src/app/api/lab/bookings/_schema.ts
+++ b/labstudio-app/src/app/api/lab/bookings/_schema.ts
@@ -1,0 +1,76 @@
+import { neon } from '@neondatabase/serverless';
+
+function sql() {
+  const url = process.env.DATABASE_URL || '';
+  if (!url) throw new Error('DATABASE_URL not configured');
+  return neon(url);
+}
+
+export async function ensureBookingSchema() {
+  const q = sql();
+
+  await q`
+    create table if not exists lab_booking_windows (
+      id bigserial primary key,
+      day_of_week integer not null, -- 0=Sun..6=Sat
+      start_time text not null, -- HH:MM (local ET)
+      end_time text not null,   -- HH:MM (local ET)
+      slot_minutes integer not null default 60,
+      active boolean not null default true,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    );
+  `;
+
+  await q`create index if not exists lab_booking_windows_active_idx on lab_booking_windows(active, day_of_week);`;
+
+  await q`
+    create table if not exists lab_bookings (
+      id bigserial primary key,
+      user_id text not null references lab_users(id) on delete cascade,
+      created_at timestamptz not null default now(),
+      day date not null,
+      time_label text not null, -- HH:MM (local ET)
+      duration_min integer not null default 60,
+      status text not null default 'requested',
+      note text,
+      unique(day, time_label)
+    );
+  `;
+
+  await q`create index if not exists lab_bookings_user_day_idx on lab_bookings(user_id, day desc, time_label);`;
+
+  // Seed a simple default schedule if empty.
+  const existing = (await q`select count(*)::int as c from lab_booking_windows;`) as any[];
+  const c = Number(existing?.[0]?.c ?? 0);
+  if (c === 0) {
+    // Weekdays: 7am-7pm hourly; Sat: 9am-1pm; Sun off.
+    const seed: Array<{ dow: number; start: string; end: string; mins: number }> = [
+      { dow: 1, start: '07:00', end: '19:00', mins: 60 },
+      { dow: 2, start: '07:00', end: '19:00', mins: 60 },
+      { dow: 3, start: '07:00', end: '19:00', mins: 60 },
+      { dow: 4, start: '07:00', end: '19:00', mins: 60 },
+      { dow: 5, start: '07:00', end: '19:00', mins: 60 },
+      { dow: 6, start: '09:00', end: '13:00', mins: 60 },
+    ];
+
+    for (const s of seed) {
+      await q`
+        insert into lab_booking_windows (day_of_week, start_time, end_time, slot_minutes, active)
+        values (${s.dow}, ${s.start}, ${s.end}, ${s.mins}, true);
+      `;
+    }
+  }
+}
+
+export function parseTimeLabelToMinutes(label: string): number | null {
+  const m = String(label || '').trim().match(/^([01]\d|2[0-3]):([0-5]\d)$/);
+  if (!m) return null;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+export function minutesToTimeLabel(total: number): string {
+  const h = Math.floor(total / 60);
+  const min = total % 60;
+  return `${String(h).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
+}

--- a/labstudio-app/src/app/api/lab/bookings/availability/route.ts
+++ b/labstudio-app/src/app/api/lab/bookings/availability/route.ts
@@ -39,7 +39,10 @@ export async function GET(req: Request) {
   }
 
   const url = new URL(req.url);
-  const days = Math.max(1, Math.min(14, Number(url.searchParams.get('days') || 7)));
+  const daysParam = url.searchParams.get('days');
+  const parsedDays = daysParam == null ? NaN : Number(daysParam);
+  const normalizedDays = Number.isFinite(parsedDays) ? Math.floor(parsedDays) : 7;
+  const days = Math.max(1, Math.min(14, normalizedDays));
 
   const jar = await cookies();
   const uid = jar.get('labstudio_uid')?.value;

--- a/labstudio-app/src/app/api/lab/bookings/availability/route.ts
+++ b/labstudio-app/src/app/api/lab/bookings/availability/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { dbConfigured, ensureSchema, getOrCreateUser } from '@/lib/db';
+import { neon } from '@neondatabase/serverless';
+import { ensureBookingSchema, minutesToTimeLabel, parseTimeLabelToMinutes } from '../_schema';
+
+export const runtime = 'nodejs';
+
+function sql() {
+  const url = process.env.DATABASE_URL || '';
+  if (!url) throw new Error('DATABASE_URL not configured');
+  return neon(url);
+}
+
+function fmtDay(d: Date): string {
+  // YYYY-MM-DD
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+function dayOfWeekInNY(d: Date): number {
+  // 0=Sun..6=Sat using NY calendar day
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+  }).formatToParts(d);
+  const wd = parts.find((p) => p.type === 'weekday')?.value || '';
+  const map: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  return map[wd] ?? d.getUTCDay();
+}
+
+export async function GET(req: Request) {
+  if (!dbConfigured()) {
+    return NextResponse.json({ ok: false, error: 'DATABASE_URL not configured' }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const days = Math.max(1, Math.min(14, Number(url.searchParams.get('days') || 7)));
+
+  const jar = await cookies();
+  const uid = jar.get('labstudio_uid')?.value;
+  if (!uid) {
+    return NextResponse.json({ ok: false, error: 'Missing labstudio_uid cookie' }, { status: 401 });
+  }
+
+  await ensureSchema();
+  await getOrCreateUser(uid);
+  await ensureBookingSchema();
+
+  const q = sql();
+  const windows = (await q`
+    select day_of_week, start_time, end_time, slot_minutes
+    from lab_booking_windows
+    where active = true
+    order by day_of_week asc, start_time asc;
+  `) as any[];
+
+  const byDow = new Map<number, Array<{ start: number; end: number; step: number }>>();
+  for (const w of windows) {
+    const s = parseTimeLabelToMinutes(String(w.start_time));
+    const e = parseTimeLabelToMinutes(String(w.end_time));
+    const step = Math.max(15, Math.min(180, Number(w.slot_minutes || 60)));
+    if (s == null || e == null || e <= s) continue;
+    const dow = Number(w.day_of_week);
+    if (!byDow.has(dow)) byDow.set(dow, []);
+    byDow.get(dow)!.push({ start: s, end: e, step });
+  }
+
+  // Pull booked slots in the visible range.
+  const startDay = fmtDay(new Date());
+  const endDay = fmtDay(new Date(Date.now() + (days + 1) * 24 * 60 * 60 * 1000));
+
+  const booked = (await q`
+    select day, time_label, status
+    from lab_bookings
+    where day >= ${startDay}::date
+      and day <= ${endDay}::date
+      and status <> 'cancelled';
+  `) as any[];
+
+  const bookedSet = new Set(booked.map((b) => `${String(b.day).slice(0, 10)}|${String(b.time_label)}`));
+
+  const out: Array<{ day: string; slots: Array<{ time_label: string; available: boolean }> }> = [];
+  for (let i = 0; i < days; i++) {
+    const d = new Date(Date.now() + i * 24 * 60 * 60 * 1000);
+    const day = fmtDay(d);
+    const dow = dayOfWeekInNY(d);
+    const windowsForDay = byDow.get(dow) || [];
+
+    const slots: Array<{ time_label: string; available: boolean }> = [];
+    for (const win of windowsForDay) {
+      for (let t = win.start; t + win.step <= win.end; t += win.step) {
+        const label = minutesToTimeLabel(t);
+        const key = `${day}|${label}`;
+        const available = !bookedSet.has(key);
+        slots.push({ time_label: label, available });
+      }
+    }
+
+    out.push({ day, slots });
+  }
+
+  return NextResponse.json({ ok: true, availability: out });
+}

--- a/labstudio-app/src/app/api/lab/bookings/route.ts
+++ b/labstudio-app/src/app/api/lab/bookings/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { neon } from '@neondatabase/serverless';
+import { dbConfigured, ensureSchema, getOrCreateUser } from '@/lib/db';
+import { ensureBookingSchema, parseTimeLabelToMinutes } from './_schema';
+
+export const runtime = 'nodejs';
+
+function sql() {
+  const url = process.env.DATABASE_URL || '';
+  if (!url) throw new Error('DATABASE_URL not configured');
+  return neon(url);
+}
+
+function fmtDay(d: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+export async function GET() {
+  if (!dbConfigured()) {
+    return NextResponse.json({ ok: false, error: 'DATABASE_URL not configured' }, { status: 400 });
+  }
+
+  const jar = await cookies();
+  const uid = jar.get('labstudio_uid')?.value;
+  if (!uid) {
+    return NextResponse.json({ ok: false, error: 'Missing labstudio_uid cookie' }, { status: 401 });
+  }
+
+  await ensureSchema();
+  await getOrCreateUser(uid);
+  await ensureBookingSchema();
+
+  const q = sql();
+  const today = fmtDay(new Date());
+
+  const upcoming = (await q`
+    select id, created_at, day, time_label, duration_min, status, note
+    from lab_bookings
+    where user_id = ${uid}
+      and day >= ${today}::date
+      and status <> 'cancelled'
+    order by day asc, time_label asc
+    limit 20;
+  `) as any[];
+
+  return NextResponse.json({ ok: true, bookings: upcoming });
+}
+
+export async function POST(req: Request) {
+  if (!dbConfigured()) {
+    return NextResponse.json({ ok: false, error: 'DATABASE_URL not configured' }, { status: 400 });
+  }
+
+  const jar = await cookies();
+  const uid = jar.get('labstudio_uid')?.value;
+  if (!uid) {
+    return NextResponse.json({ ok: false, error: 'Missing labstudio_uid cookie' }, { status: 401 });
+  }
+
+  await ensureSchema();
+  await getOrCreateUser(uid);
+  await ensureBookingSchema();
+
+  const body = (await req.json().catch(() => ({}))) as { day?: unknown; time_label?: unknown; note?: unknown };
+  const day = String((body as any)?.day || '').trim();
+  const time_label = String((body as any)?.time_label || '').trim();
+  const note = String((body as any)?.note || '').trim().slice(0, 500) || null;
+
+  if (!day.match(/^\d{4}-\d{2}-\d{2}$/)) {
+    return NextResponse.json({ ok: false, error: 'Invalid day' }, { status: 400 });
+  }
+  if (parseTimeLabelToMinutes(time_label) == null) {
+    return NextResponse.json({ ok: false, error: 'Invalid time' }, { status: 400 });
+  }
+
+  const q = sql();
+
+  try {
+    const rows = (await q`
+      insert into lab_bookings (user_id, day, time_label, duration_min, status, note)
+      values (${uid}, ${day}::date, ${time_label}, 60, 'requested', ${note})
+      returning id, created_at, day, time_label, duration_min, status, note;
+    `) as any[];
+
+    return NextResponse.json({ ok: true, booking: rows?.[0] ?? null });
+  } catch (e: any) {
+    const msg = String(e?.message || 'Failed to create booking');
+    if (msg.toLowerCase().includes('unique') || msg.toLowerCase().includes('duplicate')) {
+      return NextResponse.json({ ok: false, error: 'That slot is already booked. Please choose another time.' }, { status: 409 });
+    }
+    return NextResponse.json({ ok: false, error: 'Failed to create booking' }, { status: 500 });
+  }
+}

--- a/labstudio-app/src/app/api/lab/shop/checkout-cart/route.ts
+++ b/labstudio-app/src/app/api/lab/shop/checkout-cart/route.ts
@@ -31,6 +31,27 @@ export async function POST(req: Request) {
   await ensureSchema();
   await getOrCreateUser(uid);
 
+  // Ensure cafe table exists even if the user hasn't loaded /api/lab/cafe yet.
+  const q = sql();
+  await q`
+    create table if not exists lab_cafe_items (
+      slug text primary key,
+      name text not null,
+      category text not null,
+      price_cents integer not null,
+      product_url text,
+      image_url text,
+      stripe_product_id text,
+      stripe_price_id text,
+      active boolean not null default true,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    );
+  `;
+  await q`alter table lab_cafe_items add column if not exists image_url text;`;
+  await q`alter table lab_cafe_items add column if not exists stripe_product_id text;`;
+  await q`alter table lab_cafe_items add column if not exists stripe_price_id text;`;
+
   const body = (await req.json().catch(() => ({}))) as { lines?: unknown };
   const linesRaw = Array.isArray((body as any)?.lines) ? ((body as any).lines as any[]) : [];
   const lines: CartLine[] = linesRaw
@@ -72,7 +93,6 @@ export async function POST(req: Request) {
 
   const mode: 'subscription' | 'payment' = hasRecurring ? 'subscription' : 'payment';
 
-  const q = sql();
   const cafeSlugs = cafeLines.map((l) => l.price_id.replace(/^cafe:/, '')).filter(Boolean);
   const cafeItems = cafeSlugs.length
     ? ((await q`

--- a/labstudio-app/src/app/members/views/BookView.tsx
+++ b/labstudio-app/src/app/members/views/BookView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Calendar, Clock } from 'lucide-react';
 import Card from '../components/Card';
 
@@ -12,31 +12,106 @@ type NextBooking = {
   description: string | null;
 };
 
+type UserBooking = {
+  id: number;
+  day: string;
+  time_label: string;
+  duration_min: number;
+  status: string;
+  note: string | null;
+};
+
+type AvailabilityDay = {
+  day: string;
+  slots: Array<{ time_label: string; available: boolean }>;
+};
+
 export default function BookView() {
   const [nextBooking, setNextBooking] = useState<NextBooking | null>(null);
+  const [bookings, setBookings] = useState<UserBooking[] | null>(null);
+  const [availability, setAvailability] = useState<AvailabilityDay[] | null>(null);
+  const [note, setNote] = useState('');
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
 
-  useEffect(() => {
+  const refresh = () => {
+    setErr(null);
+
     fetch('/api/lab/home')
       .then((r) => r.json())
       .then((data) => {
         if (data?.ok) setNextBooking(data.home?.nextBooking ?? null);
       })
       .catch(() => {});
+
+    fetch('/api/lab/bookings')
+      .then((r) => r.json())
+      .then((j) => {
+        if (j?.ok) setBookings(j.bookings ?? []);
+        else setBookings([]);
+      })
+      .catch(() => setBookings([]));
+
+    fetch('/api/lab/bookings/availability?days=10')
+      .then((r) => r.json())
+      .then((j) => {
+        if (j?.ok) setAvailability(j.availability ?? []);
+        else setAvailability([]);
+      })
+      .catch(() => setAvailability([]));
+  };
+
+  useEffect(() => {
+    refresh();
   }, []);
+
+  const nextRequested = useMemo(() => {
+    if (!bookings?.length) return null;
+    return bookings[0];
+  }, [bookings]);
+
+  const requestBooking = async (day: string, time_label: string) => {
+    const key = `${day}|${time_label}`;
+    setBusyKey(key);
+    setErr(null);
+    try {
+      const res = await fetch('/api/lab/bookings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ day, time_label, note: note.trim() || null }),
+      });
+      const j = await res.json();
+      if (!j?.ok) {
+        setErr(String(j?.error || 'Failed to create booking'));
+        return;
+      }
+      setNote('');
+      refresh();
+    } catch {
+      setErr('Failed to create booking');
+    } finally {
+      setBusyKey(null);
+    }
+  };
 
   return (
     <div className="space-y-4 pb-20">
       <div className="px-1">
         <h1 className="text-2xl font-black italic uppercase">Book</h1>
-        <div className="text-xs text-zinc-500 mt-1">
-          Backed by a real Google Calendar feed (richducat@gmail.com) for now.
-        </div>
+        <div className="text-xs text-zinc-500 mt-1">Request a session + see upcoming bookings (ET).</div>
       </div>
 
+      {err ? (
+        <Card className="p-4 border border-red-500/20">
+          <div className="text-sm text-red-300 font-bold">{err}</div>
+        </Card>
+      ) : null}
+
+      {/* Calendar feed (legacy) */}
       {nextBooking ? (
         <Card className="p-4">
           <div className="flex items-center gap-2 text-violet-400 font-bold text-xs uppercase tracking-widest">
-            <Calendar size={14} /> Next session
+            <Calendar size={14} /> Next session (calendar)
           </div>
           <div className="font-black text-xl italic mt-2">{nextBooking.summary || 'Session'}</div>
           <div className="flex items-center gap-2 text-sm text-zinc-300 mt-1">
@@ -46,20 +121,88 @@ export default function BookView() {
           {nextBooking.location ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.location}</div> : null}
           {nextBooking.description ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.description}</div> : null}
         </Card>
-      ) : (
-        <Card className="p-4">
-          <div className="text-sm text-zinc-300">No upcoming session found.</div>
-          <div className="text-xs text-zinc-500 mt-2">
-            Create an event in the “LabStudio - Bookings” Google Calendar and it will appear here.
-          </div>
-        </Card>
-      )}
+      ) : null}
 
+      {/* Your bookings */}
       <Card className="p-4">
-        <div className="text-sm text-zinc-300">Create a booking (manual for now)</div>
-        <div className="text-xs text-zinc-500 mt-2">
-          We’ll wire true self-serve booking (slot selection + event creation) once we add Google API OAuth.
+        <div className="text-xs font-bold uppercase tracking-widest text-zinc-500">Your bookings</div>
+
+        {bookings === null ? (
+          <div className="text-sm text-zinc-300 mt-2">Loading…</div>
+        ) : bookings.length === 0 ? (
+          <div className="text-sm text-zinc-300 mt-2">No upcoming bookings.</div>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {bookings.map((b) => (
+              <div key={b.id} className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-bold">
+                    {b.day} @ {b.time_label} ET
+                  </div>
+                  <div className="text-xs text-zinc-500">Status: {b.status}</div>
+                  {b.note ? <div className="text-xs text-zinc-500 mt-1">Note: {b.note}</div> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {nextRequested ? <div className="text-[11px] text-zinc-500 mt-3">Tip: if you need to change a booking, message the coach for now.</div> : null}
+      </Card>
+
+      {/* Request a slot */}
+      <Card className="p-4">
+        <div className="text-xs font-bold uppercase tracking-widest text-zinc-500">Request a session</div>
+        <div className="text-xs text-zinc-500 mt-2">Pick an open slot below. We’ll confirm/adjust if needed.</div>
+
+        <div className="mt-3">
+          <div className="text-xs text-zinc-500 mb-2">Optional note</div>
+          <input
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="e.g., lower body focus / shoulder friendly"
+            className="w-full bg-zinc-900 border border-white/10 rounded-xl px-3 py-2 text-sm"
+          />
         </div>
+
+        {availability === null ? (
+          <div className="text-sm text-zinc-300 mt-3">Loading availability…</div>
+        ) : availability.length === 0 ? (
+          <div className="text-sm text-zinc-300 mt-3">No availability configured.</div>
+        ) : (
+          <div className="mt-4 space-y-3">
+            {availability.map((d) => (
+              <div key={d.day}>
+                <div className="text-xs font-bold text-zinc-400">{d.day}</div>
+                {d.slots.length === 0 ? (
+                  <div className="text-xs text-zinc-600 mt-1">No slots.</div>
+                ) : (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {d.slots.map((s) => {
+                      const key = `${d.day}|${s.time_label}`;
+                      const disabled = !s.available || busyKey === key;
+                      return (
+                        <button
+                          key={key}
+                          type="button"
+                          disabled={disabled}
+                          className={`text-xs font-black px-3 py-2 rounded-xl border ${
+                            s.available
+                              ? 'bg-yellow-400 text-zinc-950 border-yellow-400 hover:bg-yellow-300'
+                              : 'bg-white/5 text-zinc-500 border-white/10'
+                          } disabled:opacity-50`}
+                          onClick={() => requestBooking(d.day, s.time_label)}
+                        >
+                          {s.time_label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/labstudio-app/src/app/members/views/BookView.tsx
+++ b/labstudio-app/src/app/members/views/BookView.tsx
@@ -116,7 +116,7 @@ export default function BookView() {
           <div className="font-black text-xl italic mt-2">{nextBooking.summary || 'Session'}</div>
           <div className="flex items-center gap-2 text-sm text-zinc-300 mt-1">
             <Clock size={14} className="text-zinc-500" />
-            {new Date(nextBooking.start).toLocaleString()}
+            {new Date(nextBooking.start).toLocaleString('en-US', { timeZone: 'America/New_York' })}
           </div>
           {nextBooking.location ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.location}</div> : null}
           {nextBooking.description ? <div className="text-xs text-zinc-500 mt-2">{nextBooking.description}</div> : null}

--- a/memory/2026-02-19.md
+++ b/memory/2026-02-19.md
@@ -1,0 +1,11 @@
+# 2026-02-19 (Thu)
+
+## LabStudio (build blocks)
+- Continued PR #4 `LabStudio: booking requests + cafe checkout schema` on branch `feat/2026-02-19-labstudio-flows`.
+- Patch: Book view now renders the “Next session (calendar)” timestamp explicitly in ET (America/New_York) to match the UI label.
+  - Commit: f960745
+  - PR comment: https://github.com/richducat/clawd/pull/4#issuecomment-3930388815
+
+## Notes / follow-ups
+- `pnpm build` succeeded on the branch.
+- Lint is currently very noisy due to `.vercel/output` and existing `any` usage across routes; not tackled in this block.

--- a/memory/context-anchor.md
+++ b/memory/context-anchor.md
@@ -1,24 +1,27 @@
 # Context Anchor (internal)
 
-Last updated: 2026-02-16 21:02 ET
+Last updated: 2026-02-19 17:42 ET
 
 ## Source reads (internal summary)
-- ⚠️ Missing files:
-  - `/Users/richardducat/clawd/memory/goals-master.md` (not found)
-  - `/Users/richardducat/clawd/memory/2026-02-16.md` (not found)
+- ⚠️ Missing files (still not found in `/Users/richardducat/clawd/memory/`):
+  - `/Users/richardducat/clawd/memory/goals-master.md`
+  - `/Users/richardducat/clawd/memory/2026-02-16.md`
+  - Verified via `ls` + `find` (no matches). This anchor is running “blind” on goals/daily plan until fixed.
 - MEMORY.md skim (operating rules / non-negotiables):
   - Draft-first for *all* outbound emails until explicitly approved to send.
-  - Do **not** email Karen back (draft-only; no sending to Karen without explicit approval).
+  - **Do not email Karen back** automatically (draft-only; no sending without explicit approval).
   - Be proactive + low-friction: if ≥70% sure and safe/reversible, decide and proceed.
   - For code/work: PR-sized changes; do not push live; Richard tests/commits.
-  - LabStudio: **no mock data** in user-visible UI.
+  - LabStudio: **NO mock data** in user-visible UI (must be real DB/integration-backed).
   - OpenClaw dual-Mac rules: one LaunchAgent per Mac; don’t copy `~/.openclaw*`; office uses `--profile office`.
+- Recent daily memory:
+  - 2026-02-19: LabStudio work continued on branch `feat/2026-02-19-labstudio-flows` (PR #4); commit `f960745`; `pnpm build` succeeded.
 
 ## Top 10 commitments (current operating commitments)
 1) Draft-first for outbound comms; never send without explicit approval.
 2) Never email Karen back automatically (draft-only; wait for approval).
 3) Ship one tangible, testable deliverable (PR-sized) on a steady cadence.
-4) LabStudio: real DB/integration-backed UI only (no mock data).
+4) LabStudio: real DB/integration-backed UI only (no mock data in UI).
 5) TYFYS: protect privacy (no client PII/PHI leakage; rep-safe where required).
 6) Keep RingCentral automations healthy (morning posts + verification + ops brief).
 7) Keep backup jobs healthy (hourly git autosync; nightly OpenClaw state backups).
@@ -26,38 +29,57 @@ Last updated: 2026-02-16 21:02 ET
 9) Avoid drift collisions: detect/disable duplicates; minimize overlapping automations.
 10) Keep dual-Mac OpenClaw separation stable (office brain vs travel cockpit).
 
-## Today’s non-negotiables (template)
-- Courts/school watch: morning + afternoon email scans; draft-only replies.
+## Today’s non-negotiables (courts/school + backups + RC updates)
+- Courts/school watch:
+  - 7:30am ET email watch (courts + schools) (cron: `0a9c010d-...`) ✅
+  - 4:30pm ET email watch (courts + schools) (cron: `f110cf0a-...`) ✅
+  - Rule: draft-only replies.
 - Backups:
-  - Hourly git auto-sync (cron: `d43e5f81-...`) ✅ scheduled
-  - Nightly OpenClaw state backup to Drive + local sync ✅ scheduled
+  - Hourly git auto-sync (cron: `d43e5f81-...`) ✅
+  - Nightly OpenClaw state bundle → Drive (cron: `188a18be-...`) ✅
+  - Nightly OpenClaw state bundle → local Drive sync (cron: `854bc3fc-...`) ✅
 - RingCentral updates:
-  - Morning Sales Team RC update + lead buckets + KPI scoreboard + verification ✅ scheduled (weekdays)
-  - Ops brief (Mon–Sat) ✅ scheduled
+  - Weekday AM: Morning Sales Team RC update (cron: `cf636099-...`) ✅
+  - Weekday AM: Lead buckets (cron: `bd09ab42-...`) ✅
+  - Weekday AM: KPI scoreboard (cron: `728172ee-...`) ✅
+  - Weekday AM: Verification (cron: `b925e5db-...`) ✅
+  - Weekday 4pm: Day Cap RC update (cron: `08f00dea-...`) ✅
+  - Mon–Sat 6pm: TYFYS Ops Brief reminder (cron: `9c83a94e-...`) ✅
 
 ## Active workstreams + next actions
-### 1) Context anchoring
-- Next action: create the missing anchor source files (or update cron paths) so this job is grounded in real goals + daily plan.
+### 1) Anchoring / drift prevention
+- Next action (queued): restore the two missing anchor inputs so “daily goals/deadlines” + “daily plan” jobs have a canonical source.
+  - Create `memory/goals-master.md` with current goals + deadlines.
+  - Create `memory/2026-02-16.md` (retro-summary: decisions + what shipped + next-day plan) OR adjust this anchor + any jobs to point to the actual canonical file(s) if naming changed.
 
 ### 2) LabStudio
-- Next action: be ready for `LabStudio deploy: shop-on-prod-baseline` (job `e69a0b5d-...` at 2026-02-17 02:55Z) once quota resets.
-- Guardrail: do not deploy to prod without explicit approval beyond the queued job; keep changes PR-sized.
+- Current: PR #4 ongoing; branch `feat/2026-02-19-labstudio-flows`; build passes.
+- Next action: continue member-usable end-to-end flows (cafe + booking + shop/cart/checkout) with real data paths; keep PR-sized.
+- Guardrail: do not deploy to prod without explicit approval.
 
-### 3) TYFYS automations
-- Next action: keep an eye on RC/TYFYS jobs; if any start erroring, fix smallest safe issue (tokens, criteria paging, etc.).
+### 3) TYFYS automations (RingCentral + Zoho)
+- Next action: watch the inbound SMS auto-reply scanner reliability (see breakages below).
+- Continue normal ops: inbound forward-to-owner, waiting-room check-in, provider replies watch.
 
 ### 4) DriftGuard / hygiene
-- Next action: ensure any automation edits within 24h are written into this file (preflight job will also append changes).
+- Next action: capture any UI-only automation edits (preflight expects this) into this file.
 
-## Cron health (last 24h)
-- Enabled jobs with `lastStatus=error` in last 24h: **none detected**.
-- Notable errors seen (disabled one-shots): Telegram topic pings failed with `Unsupported channel: whatsapp` (jobs `df8f1ae3-...`, `464cbf82-...`, `806bdedf-...`, `0338f6fa-...`).
+## Cron health (quick)
+- Enabled jobs with `lastStatus=error` in the most recent run (approx last 24h window):
+  - `786870c7-a69b-426c-bd29-3dad3f438003` — “TYFYS inbound SMS auto-reply scanner (Sales team)” — `lastError`: `Error: cron: job execution timed out`.
+- Disabled one-shots with historical errors (not urgent): multiple “Cool Cat” Telegram-topic one-shots failed with `Unsupported channel: whatsapp`.
 
-## Detected breakages + queued fix
-1) **Missing anchor inputs**: goals-master + daily memory file paths don’t exist.
-   - Fix next work block:
-     - Create `memory/goals-master.md` (seed with current top priorities + quarterly goals).
-     - Create `memory/2026-02-16.md` (retro-log + next-day plan).
-     - OR update cron payload paths if the canonical filenames differ.
-2) **Disabled Telegram-topic one-shots misrouted**: historical jobs attempted Telegram deliveries but errored as whatsapp.
-   - Fix (low priority since disabled): delete old one-shot jobs or correct delivery channel defaults when creating future telegram posts.
+## Detected breakages + queued fix (do NOT apply now; next work block)
+1) **Missing anchor inputs**: `goals-master.md` + `2026-02-16.md` do not exist.
+   - Fix plan:
+     - Create `memory/goals-master.md` (seed: top business goals + personal/courts/school non-negotiables + LabStudio/TYFYS priorities).
+     - Create `memory/2026-02-16.md` (retro summary + decisions + next-day plan).
+     - Then verify/adjust any cron payloads that read goals-master so they use the canonical path.
+2) **Cron timeout: inbound SMS auto-reply scanner** (job `786870c7-...`).
+   - Likely cause: script runtime > timeoutSeconds (1200s) or a hang in RingCentral/Zoho paging.
+   - Fix plan:
+     - Reproduce manually with timing logs and smaller window (e.g., lookback limit / paging cap).
+     - Either optimize (pagination limits, caching, early exits) or increase cron `timeoutSeconds` (e.g., 1800–2400) if safe.
+     - Ensure summary-only output so runs remain predictable.
+3) **(Low priority) Disabled “whatsapp” delivery defaults**: old jobs show `Unsupported channel: whatsapp` despite Telegram intent.
+   - Fix plan: delete/ignore old one-shots; when creating future jobs, explicitly set delivery channel/target.


### PR DESCRIPTION
## What changed
- Added self-serve booking request flow for members (availability + create booking + list upcoming) backed by Postgres tables: lab_booking_windows and lab_bookings.
- Ensured Studio Cafe checkout works even if /api/lab/cafe hasn't been hit (checkout-cart now creates/updates lab_cafe_items schema before lookup).

## Test steps
1. pnpm dev
2. Log in / set labstudio_uid cookie (existing flow).
3. Go to Members → Book
   - See availability (next 10 days)
   - Click a slot → booking appears under "Your bookings"
   - Clicking same slot again should show an error (409)
4. Go to Members → Shop
   - Add a Studio Cafe item to cart
   - Checkout → should create Stripe Checkout session (requires STRIPE_SECRET_KEY configured)

## Risk
- New DB tables/indexes for booking; default schedule auto-seeded if empty.
- checkout-cart now creates/alters cafe table; should be safe no-op on existing DB.

## Rollback
- Revert commits 57c5272 and 4bbac6b (or close PR) to remove booking routes/UI + schema creation.
