### PR TITLE
Fix booking schema so cancelled slots can be rebooked

### DIFF
--- a/labstudio-app/src/app/api/lab/bookings/_schema.ts
+++ b/labstudio-app/src/app/api/lab/bookings/_schema.ts
@@ -34,9 +34,17 @@ export async function ensureBookingSchema() {
       time_label text not null, -- HH:MM (local ET)
       duration_min integer not null default 60,
       status text not null default 'requested',
-      note text,
-      unique(day, time_label)
+      note text
     );
+  `;
+
+  // Older deployments used a table-level unique(day, time_label) constraint.
+  // Replace it with a partial unique index so cancelled slots can be rebooked.
+  await q`alter table lab_bookings drop constraint if exists lab_bookings_day_time_label_key;`;
+  await q`
+    create unique index if not exists lab_bookings_active_slot_uniq
+      on lab_bookings(day, time_label)
+      where status <> 'cancelled';
   `;
 
   await q`create index if not exists lab_bookings_user_day_idx on lab_bookings(user_id, day desc, time_label);`;


### PR DESCRIPTION
## What changed
- Updated `ensureBookingSchema()` to remove the legacy table-level `unique(day, time_label)` booking constraint.
- Added partial unique index `lab_bookings_active_slot_uniq` on `(day, time_label)` where `status <> 'cancelled'`.

## Why
Read paths treat cancelled bookings as available, but the old global unique constraint still blocked inserts on cancelled slots. This made cancelled times appear free while being unbookable.

## Validation
- `cd labstudio-app && npm run build` passed locally.

## Risk
- Low. Schema migration is idempotent (`drop constraint if exists` + `create unique index if not exists`) and only changes uniqueness behavior for cancelled rows.

## Rollback
- Revert this PR to restore the prior schema behavior.