### PR TITLE
chore: restore .gitmodules for tracked submodules (clean follow-up)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "JSW"]
+	path = JSW
+	url = https://github.com/richducat/JSW.git
+[submodule "labstudio-fit"]
+	path = labstudio-fit
+	url = https://github.com/richducat/labstudio-fit.git
+[submodule "paid-media-buyer-pro"]
+	path = paid-media-buyer-pro
+	url = git@github.com:richducat/paid-media-buyer-pro.git
+[submodule "second-brain"]
+	path = second-brain
+	url = git@github.com:richducat/second-brain.git


### PR DESCRIPTION
## Summary
- Adds `.gitmodules` on top of current `main` so the existing gitlinks (`JSW`, `labstudio-fit`, `paid-media-buyer-pro`, `second-brain`) have canonical submodule metadata again.
- This is a clean replacement for stale PR #3, which is heavily drifted and includes unrelated app changes.

## Validation
- `git submodule status` now resolves all four tracked submodules using `.gitmodules`.

## Risk / rollback
- Low risk: metadata-only change.
- Rollback: revert this PR if needed.