### PR TITLE
Automate markdown audit in CI with strict mode

### DIFF
--- a/.github/workflows/markdown-audit.yml
+++ b/.github/workflows/markdown-audit.yml
@@ -1,0 +1,45 @@
+name: Markdown Audit
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "scripts/maintenance/markdown-audit.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/markdown-audit.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.md"
+      - "scripts/maintenance/markdown-audit.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/markdown-audit.yml"
+  schedule:
+    - cron: "15 13 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run markdown audit (strict)
+        run: npm run md:audit:strict

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -92,3 +92,17 @@ Include:
 - Deploy
 - Verify with a real production request
 - Write the next-step plan to a file
+
+## 9) Markdown Audit Automation
+- Run locally:
+  ```bash
+  npm run md:audit
+  ```
+- Run strict mode (non-zero exit on drift errors):
+  ```bash
+  npm run md:audit:strict
+  ```
+- CI workflow: `.github/workflows/markdown-audit.yml`
+  - Runs on `pull_request` / `push` when markdown or audit config changes
+  - Runs daily on schedule (`13:15 UTC`)
+  - Uses strict mode so missing core workspace markdown files or policy conflicts fail the job

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "md:audit": "node scripts/maintenance/markdown-audit.mjs",
+    "md:audit:strict": "node scripts/maintenance/markdown-audit.mjs --strict"
+  },
   "dependencies": {
     "better-sqlite3": "^11.10.0",
     "docx": "^8.5.0",

--- a/scripts/maintenance/markdown-audit.mjs
+++ b/scripts/maintenance/markdown-audit.mjs
@@ -14,6 +14,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const ROOT = process.cwd();
+const strictMode = process.argv.includes('--strict') || process.env.MARKDOWN_AUDIT_STRICT === '1';
 const mustExist = [
   'workspace.md',
   'MEMORY.md',
@@ -46,10 +47,14 @@ function has(text, needle) {
     if (!(await exists(f))) missing.push(f);
   }
 
+  let errorCount = 0;
+  let warningCount = 0;
   const lines = [];
   lines.push(`Markdown audit — ${new Date().toLocaleString('en-US', { timeZone: 'America/New_York' })}`);
+  lines.push(`Mode: ${strictMode ? 'strict' : 'report-only'}`);
 
   if (missing.length) {
+    errorCount += missing.length;
     lines.push('Missing files:');
     for (const f of missing) lines.push(`- ${f}`);
   } else {
@@ -66,13 +71,15 @@ function has(text, needle) {
   const mentionsAutoSend = has(mem, 'auto-send') || has(daily, 'auto-send');
 
   if (!wantsDraftFirst) {
+    warningCount += 1;
     lines.push('Email policy: WARNING — draft-first not found in MEMORY/daily.');
   } else {
     lines.push('Email policy: draft-first mode is recorded.');
   }
 
   if (wantsDraftFirst && mentionsAutoSend) {
-    lines.push('Email policy: NOTE — both "auto-send" and "draft-first" appear in memory; ensure draft-first is the active rule.');
+    errorCount += 1;
+    lines.push('Email policy: ERROR — both "auto-send" and "draft-first" appear in memory; ensure draft-first is the active rule.');
   }
 
   // RingCentral known issue reminder
@@ -80,8 +87,13 @@ function has(text, needle) {
 
   // Backup reminder
   lines.push('Backups: hourly git sync + nightly Drive bundle should be green (check if any repo branch lacks upstream).');
+  lines.push(`Summary: ${errorCount} error(s), ${warningCount} warning(s).`);
 
   process.stdout.write(lines.join('\n') + '\n');
+
+  if (strictMode && errorCount > 0) {
+    process.exit(1);
+  }
 })().catch((err) => {
   console.error(err?.stack || String(err));
   process.exit(1);


### PR DESCRIPTION
## Summary
- adds strict mode support to `scripts/maintenance/markdown-audit.mjs`
- adds npm scripts: `md:audit` and `md:audit:strict`
- adds GitHub Actions workflow `.github/workflows/markdown-audit.yml` to run on:
  - markdown/audit-related push + PR changes
  - daily schedule (`13:15 UTC`)
  - manual dispatch
- documents local + CI usage in `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run md:audit`
- `npm run md:audit:strict`

## Task
- Closes #8