### PR TITLE
feat(db): establish hybrid SQLite+embedding schema standard

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -1,9 +1,34 @@
 # db/
 
-This repo directory is intentionally kept light.
+This repo directory tracks schema/migration sources for local SQLite databases.
 
 Databases are stored in the local Google Drive sync folder for durability:
 
 `~/Library/CloudStorage/GoogleDrive-richducat@gmail.com/My Drive/OpenClaw Databases/`
 
 Scripts should use that location (via env var `OPENCLAW_DB_ROOT`), not commit DB files to git.
+
+## Hybrid DB standard (roadmap item #2)
+
+Canonical DB file:
+- `hybrid-core.sqlite`
+
+Migrations:
+- `db/migrations/*.sql` (ordered by filename)
+- Applied migration records are stored in the DB table `schema_migrations`.
+
+Bootstrap command:
+```bash
+npm run db:hybrid:init
+```
+
+This command:
+- Creates the DB directory if needed.
+- Opens/creates `hybrid-core.sqlite`.
+- Applies unapplied migration files transactionally.
+- Enforces checksum consistency for previously-applied migrations.
+
+Current baseline schema includes:
+- `entities` for canonical CRM/KB/Ops records
+- `entity_chunks` for chunked text and embedding vectors (stored as JSON arrays)
+- `entity_links` for typed relations between entities

--- a/db/migrations/0001_hybrid_core.sql
+++ b/db/migrations/0001_hybrid_core.sql
@@ -1,0 +1,61 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS entities (
+  id TEXT PRIMARY KEY,
+  domain TEXT NOT NULL CHECK (domain IN ('crm', 'kb', 'ops', 'mixed')),
+  type TEXT NOT NULL,
+  external_ref TEXT,
+  title TEXT,
+  body TEXT,
+  metadata_json TEXT,
+  source_system TEXT,
+  source_url TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entities_source_ref_uniq
+  ON entities(source_system, external_ref)
+  WHERE source_system IS NOT NULL AND external_ref IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_entities_domain_type
+  ON entities(domain, type);
+
+CREATE INDEX IF NOT EXISTS idx_entities_updated_at
+  ON entities(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS entity_chunks (
+  id TEXT PRIMARY KEY,
+  entity_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  token_count INTEGER,
+  embedding_model TEXT,
+  embedding_dim INTEGER,
+  embedding_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  UNIQUE(entity_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_chunks_entity
+  ON entity_chunks(entity_id, chunk_index);
+
+CREATE INDEX IF NOT EXISTS idx_entity_chunks_embedding_model
+  ON entity_chunks(embedding_model);
+
+CREATE TABLE IF NOT EXISTS entity_links (
+  from_entity_id TEXT NOT NULL,
+  to_entity_id TEXT NOT NULL,
+  relation_type TEXT NOT NULL,
+  confidence REAL,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(from_entity_id, to_entity_id, relation_type),
+  FOREIGN KEY(from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY(to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_links_to
+  ON entity_links(to_entity_id, relation_type);

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -106,3 +106,11 @@ Include:
   - Runs on `pull_request` / `push` when markdown or audit config changes
   - Runs daily on schedule (`13:15 UTC`)
   - Uses strict mode so missing core workspace markdown files or policy conflicts fail the job
+
+## 10) Hybrid DB bootstrap (SQLite + embeddings)
+- Initialize/update the hybrid standard schema:
+  ```bash
+  npm run db:hybrid:init
+  ```
+- Migration sources live in `db/migrations/`.
+- DB files should remain outside git and resolve via `OPENCLAW_DB_ROOT` (see `db/README.md`).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "db:hybrid:init": "node scripts/db/init-hybrid-db.mjs",
     "md:audit": "node scripts/maintenance/markdown-audit.mjs",
     "md:audit:strict": "node scripts/maintenance/markdown-audit.mjs --strict"
   },

--- a/scripts/db/init-hybrid-db.mjs
+++ b/scripts/db/init-hybrid-db.mjs
@@ -1,0 +1,86 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { dbPath, ensureDbDir } from '../lib/db.mjs';
+import { loadEnvLocal } from '../lib/env.mjs';
+import { openSqlite } from '../lib/sqlite.mjs';
+
+async function main() {
+  loadEnvLocal();
+  await ensureDbDir();
+
+  const targetPath = dbPath('hybrid-core.sqlite');
+  const migrationsDir = path.resolve('db/migrations');
+  const db = openSqlite(targetPath);
+
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        filename TEXT PRIMARY KEY,
+        checksum_sha256 TEXT NOT NULL,
+        applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+
+    const files = (await fs.readdir(migrationsDir))
+      .filter((name) => /^\d+.*\.sql$/.test(name))
+      .sort();
+
+    if (files.length === 0) {
+      console.log(`No migration files found in ${migrationsDir}`);
+      return;
+    }
+
+    let appliedCount = 0;
+    let skippedCount = 0;
+
+    for (const filename of files) {
+      const fullPath = path.join(migrationsDir, filename);
+      const sql = await fs.readFile(fullPath, 'utf8');
+      const checksum = sha256(sql);
+      const existing = db.prepare('SELECT checksum_sha256 FROM schema_migrations WHERE filename = ?').get(filename);
+
+      if (existing) {
+        if (existing.checksum_sha256 !== checksum) {
+          throw new Error(
+            `Migration checksum mismatch for ${filename}. Existing=${existing.checksum_sha256} New=${checksum}`,
+          );
+        }
+        skippedCount += 1;
+        continue;
+      }
+
+      const tx = db.transaction(() => {
+        db.exec(sql);
+        db.prepare(
+          'INSERT INTO schema_migrations (filename, checksum_sha256) VALUES (?, ?)',
+        ).run(filename, checksum);
+      });
+
+      tx();
+      appliedCount += 1;
+      console.log(`Applied migration: ${filename}`);
+    }
+
+    const summary = db
+      .prepare('SELECT COUNT(*) AS n FROM schema_migrations')
+      .get();
+
+    console.log(`Hybrid DB ready: ${targetPath}`);
+    console.log(`Migrations applied this run: ${appliedCount}`);
+    console.log(`Migrations skipped this run: ${skippedCount}`);
+    console.log(`Total applied migrations: ${summary.n}`);
+  } finally {
+    db.close();
+  }
+}
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Implements roadmap item #2 initial slice by establishing a migration-backed hybrid DB standard for SQLite + embedding storage.

## Changes
- Add `db/migrations/0001_hybrid_core.sql` baseline schema:
  - `entities`
  - `entity_chunks`
  - `entity_links`
- Add deterministic migration runner `scripts/db/init-hybrid-db.mjs`:
  - creates/opens `hybrid-core.sqlite`
  - creates `schema_migrations`
  - applies ordered SQL migrations transactionally
  - enforces checksum consistency for applied migration files
- Add root npm script: `db:hybrid:init`
- Document usage and standard in:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm install` (root) to ensure dependencies present
- `npm run db:hybrid:init` (first run applies migration)
- `npm run db:hybrid:init` (second run skips cleanly; idempotent)

Closes #10.