### PR TITLE
Add one-command daily hybrid DB pipeline orchestration

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -117,3 +117,43 @@ Output behavior:
 - Includes only meetings on the target date with at least one external attendee.
 - Excludes internal-only attendees using account email + internal domain filters.
 - For each external attendee, includes latest ingested Gmail touchpoint when available.
+
+## Follow-up: one-command daily hybrid pipeline
+
+Orchestrator command:
+```bash
+npm run db:hybrid:daily -- \
+  --account richducat@gmail.com \
+  --date 2026-04-19 \
+  --gmail-json scripts/db/fixtures/gmail-sample.json \
+  --calendar-json scripts/db/fixtures/calendar-sample.json \
+  --kb-from-file scripts/db/fixtures/kb-sources-sample.json \
+  --brief-out memory/meeting-prep-2026-04-19.md
+```
+
+What it runs (in order):
+- `db:hybrid:init`
+- `db:hybrid:ingest`
+- optional `db:hybrid:ingest:kb` (when KB sources are provided and `--skip-kb` is not set)
+- `db:hybrid:meeting-prep`
+
+Optional flags:
+- CRM ingest passthrough:
+  - `--account`, `--days`, `--max`, `--calendarId`
+  - `--gmail-json`, `--calendar-json`
+- KB ingest passthrough:
+  - `--kb-from-file`
+  - `--kb-file` (repeatable)
+  - `--kb-url` (repeatable)
+  - `--kb-max-chars`, `--kb-overlap-chars`
+  - `--kb-embed`, `--kb-embedding-model`
+  - `--skip-kb` to skip KB step explicitly
+- Brief output passthrough:
+  - `--date`
+  - `--internal-domain` (repeatable)
+  - `--brief-json`
+  - `--brief-out <path>` to write meeting prep output to file
+
+Output behavior:
+- The orchestrator exits non-zero if any step fails.
+- It emits a JSON summary including each step name/args and a short output preview.

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -156,3 +156,23 @@ Include:
 - Optional controls:
   - `--limit <n>` to cap number of meetings in the brief
   - `--internal-domain <domain>` (repeatable) to expand internal-only filters
+
+## 14) One-command daily hybrid pipeline
+- Run schema init + CRM ingest + optional KB ingest + meeting prep in one command:
+  ```bash
+  npm run db:hybrid:daily -- \
+    --account richducat@gmail.com \
+    --date 2026-04-18 \
+    --gmail-json scripts/db/fixtures/gmail-sample.json \
+    --calendar-json scripts/db/fixtures/calendar-sample.json \
+    --kb-from-file scripts/db/fixtures/kb-sources-sample.json \
+    --brief-out memory/meeting-prep-2026-04-18.md
+  ```
+- Behavior:
+  - Fails fast and exits non-zero if any step fails.
+  - Prints a JSON summary of executed steps and output previews.
+  - Writes the meeting prep output to a file when `--brief-out` is provided.
+- Optional controls:
+  - `--skip-kb` to disable KB ingest for a run
+  - `--brief-json` to write JSON brief output instead of markdown
+  - `--internal-domain <domain>` (repeatable) forwarded to meeting prep filtering

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "db:hybrid:ingest": "node scripts/db/ingest-gmail-calendar-hybrid.mjs",
     "db:hybrid:ingest:kb": "node scripts/db/ingest-kb-hybrid.mjs",
     "db:hybrid:meeting-prep": "node scripts/db/meeting-prep-hybrid.mjs",
+    "db:hybrid:daily": "node scripts/db/daily-hybrid-pipeline.mjs",
     "md:audit": "node scripts/maintenance/markdown-audit.mjs",
     "md:audit:strict": "node scripts/maintenance/markdown-audit.mjs --strict"
   },

--- a/scripts/db/daily-hybrid-pipeline.mjs
+++ b/scripts/db/daily-hybrid-pipeline.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});
+
+async function main() {
+  const account = getArg(args, '--account');
+  const date = getArg(args, '--date');
+  const days = getArg(args, '--days');
+  const max = getArg(args, '--max');
+  const calendarId = getArg(args, '--calendarId');
+  const gmailJson = getArg(args, '--gmail-json');
+  const calendarJson = getArg(args, '--calendar-json');
+
+  const skipKb = hasFlag(args, '--skip-kb');
+  const kbFromFile = getArg(args, '--kb-from-file');
+  const kbFiles = getArgValues(args, '--kb-file');
+  const kbUrls = getArgValues(args, '--kb-url');
+  const kbMaxChars = getArg(args, '--kb-max-chars');
+  const kbOverlapChars = getArg(args, '--kb-overlap-chars');
+  const kbEmbed = hasFlag(args, '--kb-embed');
+  const kbEmbeddingModel = getArg(args, '--kb-embedding-model');
+
+  const briefJson = hasFlag(args, '--brief-json');
+  const briefOut = getArg(args, '--brief-out');
+  const internalDomains = getArgValues(args, '--internal-domain');
+
+  const steps = [];
+
+  steps.push(runStep('init', path.join('scripts', 'db', 'init-hybrid-db.mjs'), []));
+
+  const ingestArgs = [];
+  pushArg(ingestArgs, '--account', account);
+  pushArg(ingestArgs, '--days', days);
+  pushArg(ingestArgs, '--max', max);
+  pushArg(ingestArgs, '--calendarId', calendarId);
+  pushArg(ingestArgs, '--gmail-json', gmailJson);
+  pushArg(ingestArgs, '--calendar-json', calendarJson);
+  steps.push(runStep('crm_ingest', path.join('scripts', 'db', 'ingest-gmail-calendar-hybrid.mjs'), ingestArgs));
+
+  const kbRequested = Boolean(kbFromFile || kbFiles.length || kbUrls.length);
+  if (!skipKb && kbRequested) {
+    const kbArgs = [];
+    pushArg(kbArgs, '--from-file', kbFromFile);
+    for (const file of kbFiles) {
+      pushArg(kbArgs, '--file', file);
+    }
+    for (const url of kbUrls) {
+      pushArg(kbArgs, '--url', url);
+    }
+    pushArg(kbArgs, '--max-chars', kbMaxChars);
+    pushArg(kbArgs, '--overlap-chars', kbOverlapChars);
+    if (kbEmbed) kbArgs.push('--embed');
+    pushArg(kbArgs, '--embedding-model', kbEmbeddingModel);
+
+    steps.push(runStep('kb_ingest', path.join('scripts', 'db', 'ingest-kb-hybrid.mjs'), kbArgs));
+  }
+
+  const prepArgs = [];
+  pushArg(prepArgs, '--account', account);
+  pushArg(prepArgs, '--date', date);
+  if (briefJson) prepArgs.push('--json');
+  for (const domain of internalDomains) {
+    pushArg(prepArgs, '--internal-domain', domain);
+  }
+  const prepOutput = runStep('meeting_prep', path.join('scripts', 'db', 'meeting-prep-hybrid.mjs'), prepArgs);
+  steps.push(prepOutput);
+
+  if (briefOut) {
+    const outPath = path.resolve(briefOut);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, prepOutput.output, 'utf8');
+  }
+
+  const result = {
+    ok: true,
+    ran_at: new Date().toISOString(),
+    brief_written_to: briefOut ? path.resolve(briefOut) : null,
+    kb: {
+      requested: kbRequested,
+      skipped: skipKb,
+    },
+    steps: steps.map((step) => ({
+      name: step.name,
+      script: step.script,
+      args: step.args,
+      output_preview: previewOutput(step.output),
+    })),
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function runStep(name, scriptPath, scriptArgs) {
+  const absoluteScript = path.resolve(scriptPath);
+  const output = execFileSync(process.execPath, [absoluteScript, ...scriptArgs], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return {
+    name,
+    script: scriptPath,
+    args: scriptArgs,
+    output,
+  };
+}
+
+function previewOutput(output) {
+  if (!output) return '';
+  const trimmed = String(output).trim();
+  if (!trimmed) return '';
+
+  const maxChars = 280;
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars - 3)}...`;
+}
+
+function getArg(argv, name) {
+  const i = argv.indexOf(name);
+  if (i === -1) return null;
+  return argv[i + 1] || null;
+}
+
+function getArgValues(argv, name) {
+  const values = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name && argv[i + 1]) {
+      values.push(argv[i + 1]);
+    }
+  }
+  return values;
+}
+
+function pushArg(target, name, value) {
+  if (value === null || value === undefined || value === '') return;
+  target.push(name, String(value));
+}
+
+function hasFlag(argv, name) {
+  return argv.includes(name);
+}


### PR DESCRIPTION
## Summary
- add `scripts/db/daily-hybrid-pipeline.mjs` to run the hybrid flow end-to-end in one command:
  - `db:hybrid:init`
  - `db:hybrid:ingest`
  - optional `db:hybrid:ingest:kb`
  - `db:hybrid:meeting-prep`
- add npm entrypoint: `db:hybrid:daily`
- add support for writing meeting prep output to a file via `--brief-out`
- document command usage and flags in `db/README.md` and `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run db:hybrid:daily -- --account richducat@gmail.com --date 2026-04-19 --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --kb-from-file scripts/db/fixtures/kb-sources-sample.json --brief-out memory/meeting-prep-2026-04-19.md`
- `npm run md:audit:strict`

Closes #18