### PR TITLE
ci: schedule daily hybrid pipeline with 14-day artifact retention

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -1,0 +1,105 @@
+name: Hybrid Daily Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      account:
+        description: "Account email used for self-filtering in ingest/meeting prep"
+        required: false
+        default: "richducat@gmail.com"
+      date:
+        description: "Target date for meeting prep (YYYY-MM-DD). Leave blank for today's date in ET."
+        required: false
+        default: ""
+      use_fixtures:
+        description: "Use repo fixture data for Gmail/Calendar/KB steps"
+        required: true
+        type: boolean
+        default: true
+      skip_kb:
+        description: "Skip KB ingestion step"
+        required: true
+        type: boolean
+        default: false
+  schedule:
+    - cron: "20 13 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  run-daily:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      TZ: America/New_York
+      OPENCLAW_DB_ROOT: ${{ github.workspace }}/.tmp/openclaw-db
+      ACCOUNT_INPUT: ${{ inputs.account || 'richducat@gmail.com' }}
+      DATE_INPUT: ${{ inputs.date || '' }}
+      USE_FIXTURES_INPUT: ${{ inputs.use_fixtures }}
+      SKIP_KB_INPUT: ${{ inputs.skip_kb }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build run args
+        id: args
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+
+          run_date="${DATE_INPUT}"
+          if [[ -z "$run_date" ]]; then
+            run_date="$(date +%F)"
+          fi
+
+          account="${ACCOUNT_INPUT}"
+          args=(--account "$account" --date "$run_date" --brief-out "artifacts/meeting-prep-${run_date}.md")
+
+          use_fixtures="${USE_FIXTURES_INPUT:-true}"
+          if [[ "$use_fixtures" == "true" ]]; then
+            args+=(
+              --gmail-json scripts/db/fixtures/gmail-sample.json
+              --calendar-json scripts/db/fixtures/calendar-sample.json
+            )
+            if [[ "${SKIP_KB_INPUT:-false}" != "true" ]]; then
+              args+=(--kb-from-file scripts/db/fixtures/kb-sources-sample.json)
+            fi
+          fi
+
+          if [[ "${SKIP_KB_INPUT:-false}" == "true" ]]; then
+            args+=(--skip-kb)
+          fi
+
+          {
+            echo "run_date=$run_date"
+            echo "account=$account"
+            printf 'args<<EOF\n'
+            printf '%q ' "${args[@]}"
+            printf '\nEOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run daily hybrid pipeline
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "set -- ${{ steps.args.outputs.args }}"
+          npm run db:hybrid:daily -- "$@" | tee "artifacts/pipeline-summary-${{ steps.args.outputs.run_date }}.json"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hybrid-daily-${{ steps.args.outputs.run_date }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 14

--- a/db/README.md
+++ b/db/README.md
@@ -157,3 +157,26 @@ Optional flags:
 Output behavior:
 - The orchestrator exits non-zero if any step fails.
 - It emits a JSON summary including each step name/args and a short output preview.
+
+## Scheduled daily run + artifacts (GitHub Actions)
+
+Workflow:
+- `.github/workflows/hybrid-daily-pipeline.yml`
+
+Triggers:
+- daily schedule (`13:20 UTC`)
+- manual run (`workflow_dispatch`) with inputs:
+  - `account`
+  - `date`
+  - `use_fixtures`
+  - `skip_kb`
+
+Artifacts:
+- `meeting-prep-YYYY-MM-DD.md`
+- `pipeline-summary-YYYY-MM-DD.json`
+- uploaded as workflow artifact `hybrid-daily-YYYY-MM-DD` with `retention-days: 14`
+
+Runtime notes:
+- CI sets `OPENCLAW_DB_ROOT` to a workspace-local temp directory so no DB files are committed.
+- Default mode uses repository fixtures for deterministic scheduled checks.
+- To run against live connector data, use a self-hosted runner environment where the live source prerequisites are available and set `use_fixtures=false` on manual dispatch.

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -176,3 +176,14 @@ Include:
   - `--skip-kb` to disable KB ingest for a run
   - `--brief-json` to write JSON brief output instead of markdown
   - `--internal-domain <domain>` (repeatable) forwarded to meeting prep filtering
+
+## 15) Scheduled hybrid daily run (artifact retention)
+- Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
+- Runs:
+  - daily at `13:20 UTC`
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `skip_kb`)
+- Artifacts kept for 14 days:
+  - `meeting-prep-YYYY-MM-DD.md`
+  - `pipeline-summary-YYYY-MM-DD.json`
+- Default scheduled/manual behavior uses repository fixtures for deterministic canary runs.
+- For live-source execution, run manually on an environment with live source prerequisites and set `use_fixtures=false`.


### PR DESCRIPTION
## Summary
- add `.github/workflows/hybrid-daily-pipeline.yml` to run `npm run db:hybrid:daily` on:
  - daily schedule (`13:20 UTC`)
  - manual dispatch with typed inputs (`account`, `date`, `use_fixtures`, `skip_kb`)
- default workflow mode uses fixture-backed ingest for deterministic canary runs
- upload run outputs as retained artifacts (`retention-days: 14`):
  - `meeting-prep-YYYY-MM-DD.md`
  - `pipeline-summary-YYYY-MM-DD.json`
- document scheduler and retention behavior in:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run db:hybrid:daily -- --account richducat@gmail.com --date 2026-04-19 --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --kb-from-file scripts/db/fixtures/kb-sources-sample.json --brief-out memory/meeting-prep-2026-04-19.md`
- `npm run md:audit:strict`

Closes #21