### PR TITLE
feat(db): harden live connector mode with retry/backoff + partial-failure reporting

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -97,6 +97,7 @@ jobs:
           npm run db:hybrid:daily -- "$@" | tee "artifacts/pipeline-summary-${{ steps.args.outputs.run_date }}.json"
 
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: hybrid-daily-${{ steps.args.outputs.run_date }}

--- a/db/README.md
+++ b/db/README.md
@@ -48,6 +48,10 @@ Optional flags:
 - `--calendarId <id>`: calendar source id (default `primary`)
 - `--gmail-json <path>`: ingest from JSON fixture/file instead of live `gog`
 - `--calendar-json <path>`: ingest from JSON fixture/file instead of live `gog`
+- `--allow-partial-sources`: continue ingest when exactly one live source fails (records partial failure details in JSON output)
+- `--connector-retries <n>`: retry attempts for each live `gog` call (default `2`)
+- `--connector-backoff-ms <n>`: initial retry backoff in ms for live `gog` calls (default `800`)
+- `--connector-backoff-factor <n>`: retry backoff multiplier (default `2`)
 
 Fixture validation example:
 ```bash
@@ -62,6 +66,7 @@ Design notes:
 - Retrieval text is stored in `entity_chunks` (chunk `0` for each entity).
 - Contact relations are stored in `entity_links` (`gmail_counterparty`, `calendar_attendee`).
 - `ingestion_cursors` tracks latest ingestion timestamp per source for incremental reruns.
+- Cursor updates are source-scoped: failed sources do not advance their cursor checkpoint.
 
 ## Roadmap item #4: Knowledge base ingestion (URLs + files)
 
@@ -141,6 +146,8 @@ Optional flags:
 - CRM ingest passthrough:
   - `--account`, `--days`, `--max`, `--calendarId`
   - `--gmail-json`, `--calendar-json`
+  - `--allow-partial-sources`
+  - `--connector-retries`, `--connector-backoff-ms`, `--connector-backoff-factor`
 - KB ingest passthrough:
   - `--kb-from-file`
   - `--kb-file` (repeatable)
@@ -155,8 +162,12 @@ Optional flags:
   - `--brief-out <path>` to write meeting prep output to file
 
 Output behavior:
-- The orchestrator exits non-zero if any step fails.
-- It emits a JSON summary including each step name/args and a short output preview.
+- The orchestrator always emits a JSON summary with per-step status:
+  - `ok`
+  - `partial_failure`
+  - `failed`
+- Pipeline exits non-zero only when a step is `failed`.
+- Partial source outages in CRM ingest are surfaced in summary details when `--allow-partial-sources` is enabled.
 
 ## Scheduled daily run + artifacts (GitHub Actions)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -169,13 +169,15 @@ Include:
     --brief-out memory/meeting-prep-2026-04-18.md
   ```
 - Behavior:
-  - Fails fast and exits non-zero if any step fails.
-  - Prints a JSON summary of executed steps and output previews.
+  - Always prints a JSON summary of executed steps with `ok` / `partial_failure` / `failed` status.
+  - Exits non-zero only if a step fails (`status=failed`).
   - Writes the meeting prep output to a file when `--brief-out` is provided.
 - Optional controls:
   - `--skip-kb` to disable KB ingest for a run
   - `--brief-json` to write JSON brief output instead of markdown
   - `--internal-domain <domain>` (repeatable) forwarded to meeting prep filtering
+  - `--allow-partial-sources` to allow CRM ingest to continue when one live connector source fails
+  - `--connector-retries <n>`, `--connector-backoff-ms <n>`, `--connector-backoff-factor <n>` for live connector retry/backoff tuning
 
 ## 15) Scheduled hybrid daily run (artifact retention)
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`

--- a/scripts/db/daily-hybrid-pipeline.mjs
+++ b/scripts/db/daily-hybrid-pipeline.mjs
@@ -18,6 +18,10 @@ async function main() {
   const calendarId = getArg(args, '--calendarId');
   const gmailJson = getArg(args, '--gmail-json');
   const calendarJson = getArg(args, '--calendar-json');
+  const allowPartialSources = hasFlag(args, '--allow-partial-sources');
+  const connectorRetries = getArg(args, '--connector-retries');
+  const connectorBackoffMs = getArg(args, '--connector-backoff-ms');
+  const connectorBackoffFactor = getArg(args, '--connector-backoff-factor');
 
   const skipKb = hasFlag(args, '--skip-kb');
   const kbFromFile = getArg(args, '--kb-from-file');
@@ -33,8 +37,15 @@ async function main() {
   const internalDomains = getArgValues(args, '--internal-domain');
 
   const steps = [];
+  let pipelineStatus = 'ok';
+  let fatalError = null;
 
-  steps.push(runStep('init', path.join('scripts', 'db', 'init-hybrid-db.mjs'), []));
+  const initStep = runStep('init', path.join('scripts', 'db', 'init-hybrid-db.mjs'), []);
+  steps.push(initStep);
+  if (initStep.status === 'failed') {
+    pipelineStatus = 'failed';
+    fatalError = initStep.error_message;
+  }
 
   const ingestArgs = [];
   pushArg(ingestArgs, '--account', account);
@@ -43,7 +54,25 @@ async function main() {
   pushArg(ingestArgs, '--calendarId', calendarId);
   pushArg(ingestArgs, '--gmail-json', gmailJson);
   pushArg(ingestArgs, '--calendar-json', calendarJson);
-  steps.push(runStep('crm_ingest', path.join('scripts', 'db', 'ingest-gmail-calendar-hybrid.mjs'), ingestArgs));
+  if (allowPartialSources) ingestArgs.push('--allow-partial-sources');
+  pushArg(ingestArgs, '--connector-retries', connectorRetries);
+  pushArg(ingestArgs, '--connector-backoff-ms', connectorBackoffMs);
+  pushArg(ingestArgs, '--connector-backoff-factor', connectorBackoffFactor);
+
+  if (pipelineStatus !== 'failed') {
+    const ingestStep = runStep(
+      'crm_ingest',
+      path.join('scripts', 'db', 'ingest-gmail-calendar-hybrid.mjs'),
+      ingestArgs,
+    );
+    steps.push(ingestStep);
+    if (ingestStep.status === 'partial_failure') {
+      pipelineStatus = 'partial_failure';
+    } else if (ingestStep.status === 'failed') {
+      pipelineStatus = 'failed';
+      fatalError = ingestStep.error_message;
+    }
+  }
 
   const kbRequested = Boolean(kbFromFile || kbFiles.length || kbUrls.length);
   if (!skipKb && kbRequested) {
@@ -60,7 +89,14 @@ async function main() {
     if (kbEmbed) kbArgs.push('--embed');
     pushArg(kbArgs, '--embedding-model', kbEmbeddingModel);
 
-    steps.push(runStep('kb_ingest', path.join('scripts', 'db', 'ingest-kb-hybrid.mjs'), kbArgs));
+    if (pipelineStatus !== 'failed') {
+      const kbStep = runStep('kb_ingest', path.join('scripts', 'db', 'ingest-kb-hybrid.mjs'), kbArgs);
+      steps.push(kbStep);
+      if (kbStep.status === 'failed') {
+        pipelineStatus = 'failed';
+        fatalError = kbStep.error_message;
+      }
+    }
   }
 
   const prepArgs = [];
@@ -70,47 +106,97 @@ async function main() {
   for (const domain of internalDomains) {
     pushArg(prepArgs, '--internal-domain', domain);
   }
-  const prepOutput = runStep('meeting_prep', path.join('scripts', 'db', 'meeting-prep-hybrid.mjs'), prepArgs);
-  steps.push(prepOutput);
+  let prepOutput = null;
+  if (pipelineStatus !== 'failed') {
+    prepOutput = runStep('meeting_prep', path.join('scripts', 'db', 'meeting-prep-hybrid.mjs'), prepArgs);
+    steps.push(prepOutput);
+    if (prepOutput.status === 'failed') {
+      pipelineStatus = 'failed';
+      fatalError = prepOutput.error_message;
+    }
+  }
 
-  if (briefOut) {
+  if (briefOut && prepOutput?.status !== 'failed') {
     const outPath = path.resolve(briefOut);
     fs.mkdirSync(path.dirname(outPath), { recursive: true });
     fs.writeFileSync(outPath, prepOutput.output, 'utf8');
   }
 
   const result = {
-    ok: true,
+    ok: pipelineStatus !== 'failed',
+    status: pipelineStatus,
     ran_at: new Date().toISOString(),
     brief_written_to: briefOut ? path.resolve(briefOut) : null,
     kb: {
       requested: kbRequested,
       skipped: skipKb,
     },
+    crm_ingest: {
+      allow_partial_sources: allowPartialSources,
+      connector_retries: connectorRetries !== null ? Number(connectorRetries) : null,
+      connector_backoff_ms: connectorBackoffMs !== null ? Number(connectorBackoffMs) : null,
+      connector_backoff_factor: connectorBackoffFactor !== null ? Number(connectorBackoffFactor) : null,
+    },
     steps: steps.map((step) => ({
       name: step.name,
+      status: step.status,
       script: step.script,
       args: step.args,
+      exit_code: step.exit_code,
       output_preview: previewOutput(step.output),
+      error_preview: previewOutput(step.error_output),
+      details: step.details || null,
+      error_message: step.error_message || null,
     })),
+    failure: fatalError
+      ? {
+          message: fatalError,
+        }
+      : null,
   };
 
   console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
 }
 
 function runStep(name, scriptPath, scriptArgs) {
   const absoluteScript = path.resolve(scriptPath);
-  const output = execFileSync(process.execPath, [absoluteScript, ...scriptArgs], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  try {
+    const output = execFileSync(process.execPath, [absoluteScript, ...scriptArgs], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const details = parseStepOutput(output);
+    const status = details?.status === 'partial_failure' ? 'partial_failure' : 'ok';
 
-  return {
-    name,
-    script: scriptPath,
-    args: scriptArgs,
-    output,
-  };
+    return {
+      name,
+      script: scriptPath,
+      args: scriptArgs,
+      status,
+      exit_code: 0,
+      output,
+      error_output: '',
+      details: sanitizeStepDetails(details),
+      error_message: null,
+    };
+  } catch (err) {
+    const output = err?.stdout ? String(err.stdout) : '';
+    const errorOutput = err?.stderr ? String(err.stderr) : '';
+    return {
+      name,
+      script: scriptPath,
+      args: scriptArgs,
+      status: 'failed',
+      exit_code: Number.isInteger(err?.status) ? err.status : 1,
+      output,
+      error_output: errorOutput,
+      details: sanitizeStepDetails(parseStepOutput(output)),
+      error_message: errorOutput.trim() || err?.message || `Step ${name} failed`,
+    };
+  }
 }
 
 function previewOutput(output) {
@@ -146,4 +232,27 @@ function pushArg(target, name, value) {
 
 function hasFlag(argv, name) {
   return argv.includes(name);
+}
+
+function parseStepOutput(output) {
+  const trimmed = String(output || '').trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeStepDetails(details) {
+  if (!details || typeof details !== 'object') return null;
+
+  if (details.status === 'partial_failure' || details.status === 'failed') {
+    return {
+      status: details.status,
+      failures: Array.isArray(details.failures) ? details.failures : [],
+    };
+  }
+
+  return null;
 }

--- a/scripts/db/ingest-gmail-calendar-hybrid.mjs
+++ b/scripts/db/ingest-gmail-calendar-hybrid.mjs
@@ -16,6 +16,10 @@ const max = Number(getArg(args, '--max') || '200');
 const calendarId = getArg(args, '--calendarId') || 'primary';
 const gmailJsonPath = getArg(args, '--gmail-json');
 const calendarJsonPath = getArg(args, '--calendar-json');
+const allowPartialSources = hasFlag(args, '--allow-partial-sources');
+const connectorRetries = toSafeInt(getArg(args, '--connector-retries'), 2, 0, 10);
+const connectorBackoffMs = toSafeInt(getArg(args, '--connector-backoff-ms'), 800, 0, 60_000);
+const connectorBackoffFactor = toSafeFloat(getArg(args, '--connector-backoff-factor'), 2, 1, 10);
 
 main().catch((err) => {
   console.error(err?.stack || String(err));
@@ -38,16 +42,53 @@ async function main() {
     const gmailCursor = readCursorIso(db, 'gmail', defaultSince.toISOString());
     const calendarCursor = readCursorIso(db, 'google_calendar', defaultSince.toISOString());
 
-    const gmailMessages = gmailJsonPath
-      ? normalizeGmailMessages(loadJsonFile(gmailJsonPath))
-      : fetchGmailMessages({ account, max, sinceIso: gmailCursor });
+    const retryConfig = {
+      retries: connectorRetries,
+      backoffMs: connectorBackoffMs,
+      backoffFactor: connectorBackoffFactor,
+    };
 
-    const calendarEvents = calendarJsonPath
-      ? normalizeCalendarEvents(loadJsonFile(calendarJsonPath))
-      : fetchCalendarEvents({ account, calendarId, sinceIso: calendarCursor, untilIso: now.toISOString() });
+    let gmailMessages = [];
+    let calendarEvents = [];
+    let gmailError = null;
+    let calendarError = null;
+
+    if (gmailJsonPath) {
+      gmailMessages = normalizeGmailMessages(loadJsonFile(gmailJsonPath));
+    } else {
+      try {
+        gmailMessages = await fetchGmailMessages({ account, max, sinceIso: gmailCursor, retryConfig });
+      } catch (err) {
+        gmailError = formatSourceError('gmail', err);
+        if (!allowPartialSources) throw err;
+      }
+    }
+
+    if (calendarJsonPath) {
+      calendarEvents = normalizeCalendarEvents(loadJsonFile(calendarJsonPath));
+    } else {
+      try {
+        calendarEvents = await fetchCalendarEvents({
+          account,
+          calendarId,
+          sinceIso: calendarCursor,
+          untilIso: now.toISOString(),
+          retryConfig,
+        });
+      } catch (err) {
+        calendarError = formatSourceError('google_calendar', err);
+        if (!allowPartialSources) throw err;
+      }
+    }
 
     const state = {
+      ok: true,
+      status: 'ok',
       db: targetPath,
+      config: {
+        allow_partial_sources: allowPartialSources,
+        connector_retry: retryConfig,
+      },
       window: {
         gmail_since: gmailCursor,
         calendar_since: calendarCursor,
@@ -60,6 +101,8 @@ async function main() {
         upsertedContacts: 0,
         upsertedLinks: 0,
         latestSeenAt: null,
+        cursorUpdated: false,
+        error: gmailError,
       },
       calendar: {
         source: calendarJsonPath ? path.resolve(calendarJsonPath) : 'gog',
@@ -68,8 +111,22 @@ async function main() {
         upsertedContacts: 0,
         upsertedLinks: 0,
         latestSeenAt: null,
+        cursorUpdated: false,
+        error: calendarError,
       },
     };
+
+    const failedSources = [gmailError, calendarError].filter(Boolean);
+    if (failedSources.length) {
+      if (failedSources.length === 2) {
+        state.ok = false;
+        state.status = 'failed';
+      } else {
+        state.status = 'partial_failure';
+      }
+    }
+
+    state.failures = failedSources;
 
     const tx = db.transaction(() => {
       for (const message of gmailMessages) {
@@ -80,23 +137,33 @@ async function main() {
         ingestCalendarRecord(db, event, account, state.calendar);
       }
 
-      writeCursor(db, 'gmail', {
-        last_ingested_at: state.window.until,
-        latest_seen_at: state.gmail.latestSeenAt || gmailCursor,
-        account,
-      });
+      if (!state.gmail.error) {
+        writeCursor(db, 'gmail', {
+          last_ingested_at: state.window.until,
+          latest_seen_at: state.gmail.latestSeenAt || gmailCursor,
+          account,
+        });
+        state.gmail.cursorUpdated = true;
+      }
 
-      writeCursor(db, 'google_calendar', {
-        last_ingested_at: state.window.until,
-        latest_seen_at: state.calendar.latestSeenAt || calendarCursor,
-        account,
-        calendar_id: calendarId,
-      });
+      if (!state.calendar.error) {
+        writeCursor(db, 'google_calendar', {
+          last_ingested_at: state.window.until,
+          latest_seen_at: state.calendar.latestSeenAt || calendarCursor,
+          account,
+          calendar_id: calendarId,
+        });
+        state.calendar.cursorUpdated = true;
+      }
     });
 
     tx();
 
     console.log(JSON.stringify(state, null, 2));
+
+    if (!state.ok) {
+      process.exitCode = 1;
+    }
   } finally {
     db.close();
   }
@@ -353,15 +420,23 @@ function writeCursor(db, source, payload) {
   `).run({ source, cursor_json: JSON.stringify(payload) });
 }
 
-function fetchGmailMessages({ account, max, sinceIso }) {
+async function fetchGmailMessages({ account, max, sinceIso, retryConfig }) {
   const afterEpoch = Math.floor(new Date(sinceIso).getTime() / 1000);
   const query = `after:${afterEpoch} -category:promotions -category:social`;
-  const list = gogJson(['gmail', 'messages', 'search', query, '--max', String(max), '--account', account, '--json']);
+  const list = await gogJson(
+    ['gmail', 'messages', 'search', query, '--max', String(max), '--account', account, '--json'],
+    retryConfig,
+    'gmail.messages.search',
+  );
   const messages = list?.messages || [];
 
   const out = [];
   for (const message of messages) {
-    const full = gogJson(['gmail', 'get', message.id, '--account', account, '--json']);
+    const full = await gogJson(
+      ['gmail', 'get', message.id, '--account', account, '--json'],
+      retryConfig,
+      `gmail.get:${message.id}`,
+    );
     out.push({
       id: message.id,
       threadId: message.threadId || full?.threadId || null,
@@ -378,8 +453,9 @@ function fetchGmailMessages({ account, max, sinceIso }) {
   return out;
 }
 
-function fetchCalendarEvents({ account, calendarId, sinceIso, untilIso }) {
-  const raw = gogJson([
+async function fetchCalendarEvents({ account, calendarId, sinceIso, untilIso, retryConfig }) {
+  const raw = await gogJson(
+    [
     'calendar',
     'events',
     calendarId,
@@ -390,7 +466,10 @@ function fetchCalendarEvents({ account, calendarId, sinceIso, untilIso }) {
     '--account',
     account,
     '--json',
-  ]);
+    ],
+    retryConfig,
+    'calendar.events',
+  );
 
   return normalizeCalendarEvents(raw);
 }
@@ -539,21 +618,71 @@ function assertHybridSchemaReady(db) {
   }
 }
 
-function gogJson(cmd) {
-  try {
-    const out = execFileSync('gog', cmd, { encoding: 'utf8' });
-    return JSON.parse(out);
-  } catch (err) {
-    const detail = err?.stderr ? String(err.stderr) : err?.message || String(err);
-    throw new Error(
-      `Failed to execute gog (${['gog', ...cmd].join(' ')}). ` +
-        `Either configure gog credentials or run with --gmail-json/--calendar-json fixtures. ${detail}`,
-    );
+async function gogJson(cmd, retryConfig, label) {
+  const retries = toSafeInt(retryConfig?.retries, 2, 0, 10);
+  const backoffMs = toSafeInt(retryConfig?.backoffMs, 800, 0, 60_000);
+  const backoffFactor = toSafeFloat(retryConfig?.backoffFactor, 2, 1, 10);
+  let attempt = 0;
+  let delayMs = backoffMs;
+
+  while (attempt <= retries) {
+    attempt += 1;
+    try {
+      const out = execFileSync('gog', cmd, { encoding: 'utf8' });
+      return JSON.parse(out);
+    } catch (err) {
+      const detail = err?.stderr ? String(err.stderr) : err?.message || String(err);
+      if (attempt > retries) {
+        throw new Error(
+          `Failed to execute gog (${label || ['gog', ...cmd].join(' ')}) after ${attempt} attempt(s). ` +
+            `Either configure gog credentials or run with --gmail-json/--calendar-json fixtures. ${detail}`,
+        );
+      }
+
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
+      delayMs = Math.round(delayMs * backoffFactor);
+    }
   }
+
+  throw new Error(`Unexpected retry state for ${label || ['gog', ...cmd].join(' ')}`);
 }
 
 function getArg(argv, name) {
   const index = argv.indexOf(name);
   if (index === -1) return null;
   return argv[index + 1] || null;
+}
+
+function hasFlag(argv, name) {
+  return argv.includes(name);
+}
+
+function toSafeInt(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  const rounded = Math.floor(parsed);
+  if (rounded < min) return min;
+  if (rounded > max) return max;
+  return rounded;
+}
+
+function toSafeFloat(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < min) return min;
+  if (parsed > max) return max;
+  return parsed;
+}
+
+function formatSourceError(source, err) {
+  return {
+    source,
+    message: err?.message || String(err),
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary
- harden live connector CRM ingestion with retry/backoff controls:
  - `--connector-retries`
  - `--connector-backoff-ms`
  - `--connector-backoff-factor`
- add `--allow-partial-sources` support in CRM ingest so one-source live failures surface as `status=partial_failure` with per-source error details
- ensure cursor safety: failed sources do not advance cursor checkpoints
- upgrade daily pipeline summary to always emit step statuses (`ok`, `partial_failure`, `failed`) plus structured failure details
- update daily workflow artifact upload to run with `if: always()` so failed runs still preserve artifacts/summaries
- document new flags and status behavior in `db/README.md` and `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run db:hybrid:init`
- `npm run db:hybrid:ingest -- --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --account richducat@gmail.com`
- `npm run db:hybrid:daily -- --account richducat@gmail.com --date 2026-04-19 --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --kb-from-file scripts/db/fixtures/kb-sources-sample.json --brief-out memory/meeting-prep-2026-04-19.md`
- forced partial-failure path:
  - `npm run db:hybrid:ingest -- --gmail-json scripts/db/fixtures/gmail-sample.json --calendarId definitely-not-a-real-calendar --allow-partial-sources --connector-retries 1 --connector-backoff-ms 10 --connector-backoff-factor 2 --account richducat@gmail.com`
  - `npm run db:hybrid:daily -- --account richducat@gmail.com --date 2026-04-19 --gmail-json scripts/db/fixtures/gmail-sample.json --calendarId definitely-not-a-real-calendar --allow-partial-sources --connector-retries 1 --connector-backoff-ms 10 --connector-backoff-factor 2 --brief-out artifacts/meeting-prep-partial-2026-04-19.md`
- `npm run md:audit:strict`

Closes #27