### PR TITLE
feat(db): enforce hybrid ingestion health thresholds for ops/CI

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -231,6 +231,23 @@ Optional flags:
 - `--as-of <iso>`: evaluate lag/drift against a fixed timestamp (default `now`)
 - `--artifact-dir <path>`: scan pipeline summary artifacts for failure signals (default `artifacts`)
 - `--artifacts-max <n>`: max recent `pipeline-summary-*.json` files to inspect (default `8`)
+- threshold guards (optional, non-zero exit when breached):
+  - `--max-lag-hours <n>`
+  - `--max-seen-drift-hours <n>`
+  - `--max-artifact-issues <n>`
+
+Threshold-gated example (CI/alerts):
+```bash
+npm run db:hybrid:health -- \
+  --json \
+  --max-lag-hours 24 \
+  --max-seen-drift-hours 48 \
+  --max-artifact-issues 0
+```
+
+Exit behavior:
+- Default/report-only mode (no threshold flags): exits `0`.
+- Threshold mode (one or more threshold flags): exits `2` when any configured threshold is breached.
 
 Output includes:
 - source health rows for `gmail`, `google_calendar`, `kb_ingest`:
@@ -240,3 +257,4 @@ Output includes:
 - entity/chunk coverage totals and counts grouped by `domain/type`
 - recent entity update snapshots
 - recent failure/error signals inferred from pipeline summary artifacts when present
+- threshold metadata (`thresholds`) and explicit breach records (`breaches`)

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -214,8 +214,26 @@ Include:
   - `--as-of <iso>` evaluates lag against a fixed timestamp
   - `--artifact-dir <path>` scans `pipeline-summary-*.json` artifacts for recent failure signals
   - `--artifacts-max <n>` controls how many recent artifact files to inspect
+  - threshold guards (non-zero exit on breach):
+    - `--max-lag-hours <n>`
+    - `--max-seen-drift-hours <n>`
+    - `--max-artifact-issues <n>`
 - Report fields include:
   - source cursor lag/drift for `gmail`, `google_calendar`, and `kb_ingest`
   - entity/chunk coverage totals and grouped `domain/type` counts
   - recent entity update snapshots
   - recent artifact-derived error/failure indicators (when artifacts exist)
+  - threshold metadata + explicit breach records in JSON mode
+
+CI/alerting example:
+```bash
+npm run db:hybrid:health -- \
+  --json \
+  --max-lag-hours 24 \
+  --max-seen-drift-hours 48 \
+  --max-artifact-issues 0
+```
+
+Exit behavior:
+- no threshold flags: report-only, exits `0`
+- one or more threshold flags set: exits `2` if any configured threshold is breached

--- a/scripts/db/hybrid-ingestion-health.mjs
+++ b/scripts/db/hybrid-ingestion-health.mjs
@@ -11,6 +11,12 @@ const asOfArg = getArg(args, '--as-of');
 const artifactDirArg = getArg(args, '--artifact-dir') || 'artifacts';
 const artifactsMax = toSafeInt(getArg(args, '--artifacts-max'), 8, 1, 100);
 const jsonMode = hasFlag(args, '--json');
+const thresholds = {
+  max_lag_hours: readOptionalNumberArg(args, '--max-lag-hours'),
+  max_seen_drift_hours: readOptionalNumberArg(args, '--max-seen-drift-hours'),
+  max_artifact_issues: readOptionalNumberArg(args, '--max-artifact-issues'),
+};
+const hasThresholds = Object.values(thresholds).some((value) => value !== null);
 
 const DEFAULT_SOURCES = ['gmail', 'google_calendar', 'kb_ingest'];
 
@@ -36,9 +42,14 @@ async function main() {
     const entityByDomainType = readEntityByDomainType(db);
     const recentEntityUpdates = readRecentEntityUpdates(db);
     const failureSummary = readFailureSummary(artifactDirArg, artifactsMax);
+    const breaches = evaluateThresholdBreaches({
+      sources: sourceHealth,
+      failures: failureSummary,
+      thresholds,
+    });
 
     const result = {
-      ok: true,
+      ok: hasThresholds ? breaches.length === 0 : true,
       as_of: asOf.toISOString(),
       db: dbPath('hybrid-core.sqlite'),
       sources: sourceHealth,
@@ -46,14 +57,25 @@ async function main() {
       by_domain_type: entityByDomainType,
       recent_updates: recentEntityUpdates,
       failures: failureSummary,
+      thresholds: {
+        configured: hasThresholds,
+        ...thresholds,
+      },
+      breaches,
     };
 
     if (jsonMode) {
       console.log(JSON.stringify(result, null, 2));
+      if (hasThresholds && breaches.length) {
+        process.exitCode = 2;
+      }
       return;
     }
 
     printMarkdown(result, artifactDirArg);
+    if (hasThresholds && breaches.length) {
+      process.exitCode = 2;
+    }
   } finally {
     db.close();
   }
@@ -277,6 +299,31 @@ function printMarkdown(result, artifactDirInput) {
     const stepText = issue.step ? ` step=${issue.step}` : '';
     console.log(`- [${issue.level}] ${issue.file}${stepText}: ${issue.message}`);
   }
+  console.log('');
+
+  console.log('## Threshold Evaluation');
+  if (!result.thresholds?.configured) {
+    console.log('- no thresholds configured (report-only mode)');
+    return;
+  }
+
+  console.log(`- max_lag_hours=${formatNumber(result.thresholds.max_lag_hours)}`);
+  console.log(`- max_seen_drift_hours=${formatNumber(result.thresholds.max_seen_drift_hours)}`);
+  console.log(`- max_artifact_issues=${formatNumber(result.thresholds.max_artifact_issues)}`);
+  console.log(`- breaches=${result.breaches.length}`);
+
+  if (!result.breaches.length) {
+    console.log('- all configured thresholds passed');
+    return;
+  }
+
+  for (const breach of result.breaches) {
+    if (breach.kind === 'artifact_issues_count') {
+      console.log(`- [breach] artifact issues: actual=${breach.actual} > limit=${breach.limit}`);
+      continue;
+    }
+    console.log(`- [breach] ${breach.source} ${breach.kind}: actual=${breach.actual} > limit=${breach.limit}`);
+  }
 }
 
 function assertSchemaReady(db) {
@@ -328,6 +375,16 @@ function getArg(argv, name) {
   return argv[i + 1] || null;
 }
 
+function readOptionalNumberArg(argv, name) {
+  const raw = getArg(argv, name);
+  if (raw === null) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid ${name} value: ${raw}. Expected a non-negative number.`);
+  }
+  return Number(value.toFixed(3));
+}
+
 function hasFlag(argv, name) {
   return argv.includes(name);
 }
@@ -372,4 +429,49 @@ function truncate(input, maxLen) {
 function formatNumber(value) {
   if (value === null || value === undefined || Number.isNaN(value)) return 'n/a';
   return String(value);
+}
+
+function evaluateThresholdBreaches({ sources, failures, thresholds }) {
+  const breaches = [];
+
+  if (thresholds.max_lag_hours !== null) {
+    for (const source of sources) {
+      if (source.lag_hours === null || source.lag_hours === undefined) continue;
+      if (source.lag_hours > thresholds.max_lag_hours) {
+        breaches.push({
+          kind: 'lag_hours',
+          source: source.source,
+          actual: source.lag_hours,
+          limit: thresholds.max_lag_hours,
+        });
+      }
+    }
+  }
+
+  if (thresholds.max_seen_drift_hours !== null) {
+    for (const source of sources) {
+      if (source.seen_drift_hours === null || source.seen_drift_hours === undefined) continue;
+      if (source.seen_drift_hours > thresholds.max_seen_drift_hours) {
+        breaches.push({
+          kind: 'seen_drift_hours',
+          source: source.source,
+          actual: source.seen_drift_hours,
+          limit: thresholds.max_seen_drift_hours,
+        });
+      }
+    }
+  }
+
+  if (thresholds.max_artifact_issues !== null) {
+    const issueCount = Array.isArray(failures?.issues) ? failures.issues.length : 0;
+    if (issueCount > thresholds.max_artifact_issues) {
+      breaches.push({
+        kind: 'artifact_issues_count',
+        actual: issueCount,
+        limit: thresholds.max_artifact_issues,
+      });
+    }
+  }
+
+  return breaches;
 }


### PR DESCRIPTION
## Summary
- extend `db:hybrid:health` with optional threshold flags:
  - `--max-lag-hours`
  - `--max-seen-drift-hours`
  - `--max-artifact-issues`
- add deterministic threshold metadata and breach records to output:
  - `thresholds` block (`configured` + effective values)
  - `breaches` array with typed breach details
- keep report-only behavior unchanged when no thresholds are provided
- add threshold-gated exit behavior:
  - no threshold flags => exit `0`
  - thresholds configured + breach => exit `2`
- update docs in `db/README.md` and `docs/RUNBOOK_DEPLOY_GENERIC.md` with CI/alerting examples and exit semantics

## Validation
- `npm run db:hybrid:health`
- `npm run db:hybrid:health -- --json --max-lag-hours 999 --max-seen-drift-hours 999 --max-artifact-issues 999`
- forced breach path (expected non-zero):
  - `npm run db:hybrid:health -- --json --max-lag-hours 0 --max-seen-drift-hours 0 --max-artifact-issues 0`
  - observed exit code: `2`
- `npm run md:audit:strict`

Closes #29