### PR TITLE
ci(db): gate hybrid daily pipeline with ingestion health thresholds

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -21,6 +21,18 @@ on:
         required: true
         type: boolean
         default: false
+      max_lag_hours:
+        description: "Health gate: max ingestion lag hours before breach"
+        required: false
+        default: "24"
+      max_seen_drift_hours:
+        description: "Health gate: max seen drift hours before breach"
+        required: false
+        default: "48"
+      max_artifact_issues:
+        description: "Health gate: max artifact-derived issue count before breach"
+        required: false
+        default: "0"
   schedule:
     - cron: "20 13 * * *"
 
@@ -38,6 +50,9 @@ jobs:
       DATE_INPUT: ${{ inputs.date || '' }}
       USE_FIXTURES_INPUT: ${{ inputs.use_fixtures }}
       SKIP_KB_INPUT: ${{ inputs.skip_kb }}
+      MAX_LAG_HOURS_INPUT: ${{ inputs.max_lag_hours || '24' }}
+      MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
+      MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,6 +110,24 @@ jobs:
           set -euo pipefail
           eval "set -- ${{ steps.args.outputs.args }}"
           npm run db:hybrid:daily -- "$@" | tee "artifacts/pipeline-summary-${{ steps.args.outputs.run_date }}.json"
+
+      - name: Run ingestion health threshold gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_date="${{ steps.args.outputs.run_date }}"
+
+          npm run db:hybrid:health -- \
+            --artifact-dir artifacts \
+            > "artifacts/ingestion-health-${run_date}.md"
+
+          npm run db:hybrid:health -- \
+            --json \
+            --artifact-dir artifacts \
+            --max-lag-hours "${MAX_LAG_HOURS_INPUT}" \
+            --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}" \
+            --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \
+            | tee "artifacts/ingestion-health-${run_date}.json"
 
       - name: Upload artifacts
         if: always()

--- a/db/README.md
+++ b/db/README.md
@@ -181,16 +181,28 @@ Triggers:
   - `date`
   - `use_fixtures`
   - `skip_kb`
+  - `max_lag_hours`
+  - `max_seen_drift_hours`
+  - `max_artifact_issues`
 
 Artifacts:
 - `meeting-prep-YYYY-MM-DD.md`
 - `pipeline-summary-YYYY-MM-DD.json`
+- `ingestion-health-YYYY-MM-DD.md`
+- `ingestion-health-YYYY-MM-DD.json`
 - uploaded as workflow artifact `hybrid-daily-YYYY-MM-DD` with `retention-days: 14`
 
 Runtime notes:
 - CI sets `OPENCLAW_DB_ROOT` to a workspace-local temp directory so no DB files are committed.
 - Default mode uses repository fixtures for deterministic scheduled checks.
 - To run against live connector data, use a self-hosted runner environment where the live source prerequisites are available and set `use_fixtures=false` on manual dispatch.
+- The workflow runs `db:hybrid:health` after the daily pipeline:
+  - markdown report mode (artifact-only)
+  - threshold-gated JSON mode with defaults:
+    - `--max-lag-hours 24`
+    - `--max-seen-drift-hours 48`
+    - `--max-artifact-issues 0`
+- Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -183,12 +183,22 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `skip_kb`)
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
+  - `ingestion-health-YYYY-MM-DD.md`
+  - `ingestion-health-YYYY-MM-DD.json`
 - Default scheduled/manual behavior uses repository fixtures for deterministic canary runs.
 - For live-source execution, run manually on an environment with live source prerequisites and set `use_fixtures=false`.
+- Workflow health gate:
+  - runs `db:hybrid:health` after `db:hybrid:daily`
+  - emits both markdown and JSON health artifacts
+  - default breach thresholds:
+    - `max_lag_hours=24`
+    - `max_seen_drift_hours=48`
+    - `max_artifact_issues=0`
+  - threshold breach exits `2` and fails the run (artifacts still upload because upload step uses `if: always()`)
 
 ## 16) Hybrid retrieval query (entities + chunks)
 - Run ranked retrieval:


### PR DESCRIPTION
## Summary
- extend `.github/workflows/hybrid-daily-pipeline.yml` with post-pipeline health gating
- run `db:hybrid:health` in two modes:
  - markdown artifact output (`ingestion-health-YYYY-MM-DD.md`)
  - threshold-gated JSON mode (`ingestion-health-YYYY-MM-DD.json`)
- add manual dispatch threshold inputs:
  - `max_lag_hours` (default `24`)
  - `max_seen_drift_hours` (default `48`)
  - `max_artifact_issues` (default `0`)
- preserve artifact availability on failures via existing upload step (`if: always()`)
- update docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run db:hybrid:daily -- --account richducat@gmail.com --date 2026-04-19 --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --kb-from-file scripts/db/fixtures/kb-sources-sample.json --brief-out artifacts/meeting-prep-2026-04-19.md`
- `npm run db:hybrid:health -- --json --artifact-dir artifacts --max-lag-hours 24 --max-seen-drift-hours 48 --max-artifact-issues 0`
- `npm run md:audit:strict`

Closes #31