### PR TITLE
ci(db): add health-gate breach alert webhook step

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -137,3 +137,42 @@ jobs:
           path: artifacts/
           if-no-files-found: error
           retention-days: 14
+
+      - name: Alert on health-gate breach
+        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL != '' }}
+        env:
+          ALERT_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_WEBHOOK_URL }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          BRANCH_REF: ${{ github.ref_name }}
+          RUN_DATE: ${{ steps.args.outputs.run_date }}
+          MAX_LAG_HOURS: ${{ env.MAX_LAG_HOURS_INPUT }}
+          MAX_SEEN_DRIFT_HOURS: ${{ env.MAX_SEEN_DRIFT_HOURS_INPUT }}
+          MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          payload="$(node -e '
+            const body = [
+              `:rotating_light: Hybrid daily pipeline health gate breached`,
+              `Repo: ${process.env.REPO}`,
+              `Branch: ${process.env.BRANCH_REF}`,
+              `Run date: ${process.env.RUN_DATE}`,
+              `Thresholds: lag<=${process.env.MAX_LAG_HOURS}h, drift<=${process.env.MAX_SEEN_DRIFT_HOURS}h, artifactIssues<=${process.env.MAX_ARTIFACT_ISSUES}`,
+              `Run: ${process.env.RUN_URL}`,
+              `Artifacts: hybrid-daily-${process.env.RUN_DATE} (see run page)`
+            ].join(`\n`);
+            process.stdout.write(JSON.stringify({ text: body }));
+          ')"
+          curl --fail --show-error --silent \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$ALERT_WEBHOOK_URL"
+
+      - name: Alert webhook not configured
+        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL == '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Health gate breached but HYBRID_ALERT_WEBHOOK_URL is not configured. Add this repo secret to enable notifications."

--- a/db/README.md
+++ b/db/README.md
@@ -203,6 +203,10 @@ Runtime notes:
     - `--max-seen-drift-hours 48`
     - `--max-artifact-issues 0`
 - Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
+- Optional breach alerting:
+  - configure repo secret `HYBRID_ALERT_WEBHOOK_URL`
+  - when set, a failing health gate posts a JSON payload (`text` field) containing run URL, run date, threshold settings, and artifact label
+  - when unset, the workflow logs a warning and skips outbound notification
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -199,6 +199,13 @@ Include:
     - `max_seen_drift_hours=48`
     - `max_artifact_issues=0`
   - threshold breach exits `2` and fails the run (artifacts still upload because upload step uses `if: always()`)
+- Optional breach alert hook:
+  - set repo secret `HYBRID_ALERT_WEBHOOK_URL` to enable outbound notifications
+  - on health-gate failure, workflow posts a JSON payload (`text`) with:
+    - run URL
+    - run date + threshold values
+    - artifact label (`hybrid-daily-YYYY-MM-DD`)
+  - if the secret is not set, workflow logs a warning and skips notification
 
 ## 16) Hybrid retrieval query (entities + chunks)
 - Run ranked retrieval:


### PR DESCRIPTION
## Summary
- extend `.github/workflows/hybrid-daily-pipeline.yml` with post-failure alerting
- trigger outbound alert only when health gate fails and `HYBRID_ALERT_WEBHOOK_URL` secret is configured
- include run URL, run date, threshold settings, and artifact label in webhook payload (`text`)
- add explicit fallback step that logs a warning when webhook secret is not configured
- update docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `npm run md:audit:strict`

Closes #34