### PR TITLE
feat(db): add source-level ingestion reconciliation guardrails

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -33,6 +33,7 @@ Current baseline schema includes:
 - `entity_chunks` for chunked text and embedding vectors (stored as JSON arrays)
 - `entity_links` for typed relations between entities
 - `ingestion_cursors` for incremental source checkpointing
+- `ingestion_run_metrics` for per-source run counters and reconciliation checks
 
 ## Roadmap item #3: Gmail + Calendar daily ingestion
 
@@ -260,6 +261,9 @@ Optional flags:
   - `--max-lag-hours <n>`
   - `--max-seen-drift-hours <n>`
   - `--max-artifact-issues <n>`
+  - `--max-entity-delta-pct <n>`
+  - `--max-chunk-ratio-delta <n>`
+  - `--max-link-delta-pct <n>`
 
 Threshold-gated example (CI/alerts):
 ```bash
@@ -282,4 +286,9 @@ Output includes:
 - entity/chunk coverage totals and counts grouped by `domain/type`
 - recent entity update snapshots
 - recent failure/error signals inferred from pipeline summary artifacts when present
+- source-level reconciliation from `ingestion_run_metrics`:
+  - latest vs previous run counters per source
+  - entity delta + entity delta %
+  - chunk-per-entity ratio drift
+  - link delta + link delta %
 - threshold metadata (`thresholds`) and explicit breach records (`breaches`)

--- a/db/migrations/0003_ingestion_run_metrics.sql
+++ b/db/migrations/0003_ingestion_run_metrics.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS ingestion_run_metrics (
+  run_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('ok', 'partial_failure', 'failed')),
+  run_started_at TEXT NOT NULL,
+  run_completed_at TEXT NOT NULL,
+  records_scanned INTEGER NOT NULL DEFAULT 0,
+  entities_upserted INTEGER NOT NULL DEFAULT 0,
+  chunks_upserted INTEGER NOT NULL DEFAULT 0,
+  links_upserted INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  metrics_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (run_id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_run_metrics_source_completed
+  ON ingestion_run_metrics(source, run_completed_at DESC);

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -246,11 +246,18 @@ Include:
     - `--max-lag-hours <n>`
     - `--max-seen-drift-hours <n>`
     - `--max-artifact-issues <n>`
+    - `--max-entity-delta-pct <n>`
+    - `--max-chunk-ratio-delta <n>`
+    - `--max-link-delta-pct <n>`
 - Report fields include:
   - source cursor lag/drift for `gmail`, `google_calendar`, and `kb_ingest`
   - entity/chunk coverage totals and grouped `domain/type` counts
   - recent entity update snapshots
   - recent artifact-derived error/failure indicators (when artifacts exist)
+  - source reconciliation (latest vs previous run) from `ingestion_run_metrics`, including:
+    - entity delta + entity delta %
+    - chunk-per-entity ratio drift
+    - link delta + link delta %
   - threshold metadata + explicit breach records in JSON mode
 
 CI/alerting example:

--- a/scripts/db/hybrid-ingestion-health.mjs
+++ b/scripts/db/hybrid-ingestion-health.mjs
@@ -15,6 +15,9 @@ const thresholds = {
   max_lag_hours: readOptionalNumberArg(args, '--max-lag-hours'),
   max_seen_drift_hours: readOptionalNumberArg(args, '--max-seen-drift-hours'),
   max_artifact_issues: readOptionalNumberArg(args, '--max-artifact-issues'),
+  max_entity_delta_pct: readOptionalNumberArg(args, '--max-entity-delta-pct'),
+  max_chunk_ratio_delta: readOptionalNumberArg(args, '--max-chunk-ratio-delta'),
+  max_link_delta_pct: readOptionalNumberArg(args, '--max-link-delta-pct'),
 };
 const hasThresholds = Object.values(thresholds).some((value) => value !== null);
 
@@ -42,9 +45,11 @@ async function main() {
     const entityByDomainType = readEntityByDomainType(db);
     const recentEntityUpdates = readRecentEntityUpdates(db);
     const failureSummary = readFailureSummary(artifactDirArg, artifactsMax);
+    const reconciliation = readSourceReconciliation(db);
     const breaches = evaluateThresholdBreaches({
       sources: sourceHealth,
       failures: failureSummary,
+      reconciliation,
       thresholds,
     });
 
@@ -57,6 +62,7 @@ async function main() {
       by_domain_type: entityByDomainType,
       recent_updates: recentEntityUpdates,
       failures: failureSummary,
+      reconciliation,
       thresholds: {
         configured: hasThresholds,
         ...thresholds,
@@ -301,6 +307,17 @@ function printMarkdown(result, artifactDirInput) {
   }
   console.log('');
 
+  console.log('## Reconciliation');
+  if (!result.reconciliation?.available) {
+    console.log(`- ${result.reconciliation?.note || 'reconciliation unavailable'}`);
+  } else {
+    console.log(`- compared sources: ${result.reconciliation.sources.length}`);
+    for (const source of result.reconciliation.sources) {
+      console.log(`- ${source.source}: status=${source.status}, current_run_at=${source.current?.run_completed_at || 'n/a'}, previous_run_at=${source.previous?.run_completed_at || 'n/a'}, entity_delta=${formatNumber(source.deltas.entity_delta)}, entity_delta_pct=${formatNumber(source.deltas.entity_delta_pct)}, chunk_ratio_delta=${formatNumber(source.deltas.chunk_ratio_delta)}, link_delta=${formatNumber(source.deltas.link_delta)}, link_delta_pct=${formatNumber(source.deltas.link_delta_pct)}`);
+    }
+  }
+  console.log('');
+
   console.log('## Threshold Evaluation');
   if (!result.thresholds?.configured) {
     console.log('- no thresholds configured (report-only mode)');
@@ -310,6 +327,9 @@ function printMarkdown(result, artifactDirInput) {
   console.log(`- max_lag_hours=${formatNumber(result.thresholds.max_lag_hours)}`);
   console.log(`- max_seen_drift_hours=${formatNumber(result.thresholds.max_seen_drift_hours)}`);
   console.log(`- max_artifact_issues=${formatNumber(result.thresholds.max_artifact_issues)}`);
+  console.log(`- max_entity_delta_pct=${formatNumber(result.thresholds.max_entity_delta_pct)}`);
+  console.log(`- max_chunk_ratio_delta=${formatNumber(result.thresholds.max_chunk_ratio_delta)}`);
+  console.log(`- max_link_delta_pct=${formatNumber(result.thresholds.max_link_delta_pct)}`);
   console.log(`- breaches=${result.breaches.length}`);
 
   if (!result.breaches.length) {
@@ -322,8 +342,105 @@ function printMarkdown(result, artifactDirInput) {
       console.log(`- [breach] artifact issues: actual=${breach.actual} > limit=${breach.limit}`);
       continue;
     }
+    if (breach.kind === 'reconciliation_unavailable') {
+      console.log(`- [breach] reconciliation unavailable: ${breach.message}`);
+      continue;
+    }
     console.log(`- [breach] ${breach.source} ${breach.kind}: actual=${breach.actual} > limit=${breach.limit}`);
   }
+}
+
+function readSourceReconciliation(db) {
+  if (!tableExists(db, 'ingestion_run_metrics')) {
+    return {
+      available: false,
+      note: 'ingestion_run_metrics table missing (run npm run db:hybrid:init)',
+      sources: [],
+    };
+  }
+
+  const rows = db.prepare(`
+    SELECT
+      source,
+      run_id,
+      status,
+      run_completed_at,
+      records_scanned,
+      entities_upserted,
+      chunks_upserted,
+      links_upserted,
+      error_message
+    FROM ingestion_run_metrics
+    WHERE source IN (${DEFAULT_SOURCES.map(() => '?').join(',')})
+    ORDER BY source ASC, run_completed_at DESC, run_id DESC
+  `).all(...DEFAULT_SOURCES);
+
+  const grouped = new Map();
+  for (const row of rows) {
+    const source = String(row.source);
+    if (!grouped.has(source)) grouped.set(source, []);
+    const list = grouped.get(source);
+    if (list.length < 2) {
+      list.push({
+        run_id: row.run_id,
+        status: row.status,
+        run_completed_at: toIsoOrNull(row.run_completed_at),
+        records_scanned: Number(row.records_scanned || 0),
+        entities_upserted: Number(row.entities_upserted || 0),
+        chunks_upserted: Number(row.chunks_upserted || 0),
+        links_upserted: Number(row.links_upserted || 0),
+        error_message: row.error_message || null,
+      });
+    }
+  }
+
+  const sources = DEFAULT_SOURCES.map((source) => {
+    const pair = grouped.get(source) || [];
+    const current = pair[0] || null;
+    const previous = pair[1] || null;
+
+    if (!current || !previous) {
+      return {
+        source,
+        status: 'insufficient_history',
+        current,
+        previous,
+        deltas: {
+          entity_delta: null,
+          entity_delta_pct: null,
+          chunk_ratio_delta: null,
+          link_delta: null,
+          link_delta_pct: null,
+        },
+      };
+    }
+
+    const currentRatio = ratio(current.chunks_upserted, current.entities_upserted);
+    const previousRatio = ratio(previous.chunks_upserted, previous.entities_upserted);
+
+    const entityDelta = current.entities_upserted - previous.entities_upserted;
+    const linkDelta = current.links_upserted - previous.links_upserted;
+
+    return {
+      source,
+      status: 'ok',
+      current,
+      previous,
+      deltas: {
+        entity_delta: entityDelta,
+        entity_delta_pct: percentDelta(current.entities_upserted, previous.entities_upserted),
+        chunk_ratio_delta: absoluteDelta(currentRatio, previousRatio),
+        link_delta: linkDelta,
+        link_delta_pct: percentDelta(current.links_upserted, previous.links_upserted),
+      },
+    };
+  });
+
+  return {
+    available: true,
+    note: rows.length ? null : 'no ingestion run history found yet',
+    sources,
+  };
 }
 
 function assertSchemaReady(db) {
@@ -339,6 +456,15 @@ function assertSchemaReady(db) {
   if (missing.length) {
     throw new Error(`Missing required tables: ${missing.join(', ')}. Run npm run db:hybrid:init first.`);
   }
+}
+
+function tableExists(db, tableName) {
+  const row = db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table' AND name = ?
+  `).get(tableName);
+  return Boolean(row?.name);
 }
 
 function classifyLag(lagHours, lastIngestedAt) {
@@ -431,7 +557,7 @@ function formatNumber(value) {
   return String(value);
 }
 
-function evaluateThresholdBreaches({ sources, failures, thresholds }) {
+function evaluateThresholdBreaches({ sources, failures, reconciliation, thresholds }) {
   const breaches = [];
 
   if (thresholds.max_lag_hours !== null) {
@@ -473,5 +599,77 @@ function evaluateThresholdBreaches({ sources, failures, thresholds }) {
     }
   }
 
+  if (!reconciliation?.available) {
+    const hasReconciliationThresholds = thresholds.max_entity_delta_pct !== null
+      || thresholds.max_chunk_ratio_delta !== null
+      || thresholds.max_link_delta_pct !== null;
+    if (hasReconciliationThresholds) {
+      breaches.push({
+        kind: 'reconciliation_unavailable',
+        message: reconciliation?.note || 'missing reconciliation data',
+      });
+    }
+    return breaches;
+  }
+
+  for (const source of reconciliation.sources || []) {
+    if (source.status !== 'ok') continue;
+
+    if (
+      thresholds.max_entity_delta_pct !== null
+      && source.deltas.entity_delta_pct !== null
+      && source.deltas.entity_delta_pct > thresholds.max_entity_delta_pct
+    ) {
+      breaches.push({
+        kind: 'entity_delta_pct',
+        source: source.source,
+        actual: source.deltas.entity_delta_pct,
+        limit: thresholds.max_entity_delta_pct,
+      });
+    }
+
+    if (
+      thresholds.max_chunk_ratio_delta !== null
+      && source.deltas.chunk_ratio_delta !== null
+      && source.deltas.chunk_ratio_delta > thresholds.max_chunk_ratio_delta
+    ) {
+      breaches.push({
+        kind: 'chunk_ratio_delta',
+        source: source.source,
+        actual: source.deltas.chunk_ratio_delta,
+        limit: thresholds.max_chunk_ratio_delta,
+      });
+    }
+
+    if (
+      thresholds.max_link_delta_pct !== null
+      && source.deltas.link_delta_pct !== null
+      && source.deltas.link_delta_pct > thresholds.max_link_delta_pct
+    ) {
+      breaches.push({
+        kind: 'link_delta_pct',
+        source: source.source,
+        actual: source.deltas.link_delta_pct,
+        limit: thresholds.max_link_delta_pct,
+      });
+    }
+  }
+
   return breaches;
+}
+
+function ratio(numerator, denominator) {
+  if (!denominator) return 0;
+  return Number((numerator / denominator).toFixed(6));
+}
+
+function percentDelta(current, previous) {
+  if (previous === null || previous === undefined) return null;
+  if (previous === 0) return current === 0 ? 0 : 100;
+  return Number(((Math.abs(current - previous) / previous) * 100).toFixed(3));
+}
+
+function absoluteDelta(current, previous) {
+  if (current === null || previous === null || current === undefined || previous === undefined) return null;
+  return Number(Math.abs(current - previous).toFixed(6));
 }

--- a/scripts/db/ingest-gmail-calendar-hybrid.mjs
+++ b/scripts/db/ingest-gmail-calendar-hybrid.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -29,6 +30,7 @@ main().catch((err) => {
 async function main() {
   loadEnvLocal();
   await ensureDbDir();
+  const runStartedAt = new Date().toISOString();
 
   const targetPath = dbPath('hybrid-core.sqlite');
   const db = openSqlite(targetPath);
@@ -155,6 +157,31 @@ async function main() {
         });
         state.calendar.cursorUpdated = true;
       }
+
+      const runCompletedAt = new Date().toISOString();
+      const runId = crypto.randomUUID();
+      writeIngestionRunMetric(db, buildSourceMetric({
+        runId,
+        source: 'gmail',
+        sourceSummary: state.gmail,
+        runStartedAt,
+        runCompletedAt,
+        extraMetrics: {
+          cursor_updated: state.gmail.cursorUpdated,
+          mode: gmailJsonPath ? 'fixture' : 'live',
+        },
+      }));
+      writeIngestionRunMetric(db, buildSourceMetric({
+        runId,
+        source: 'google_calendar',
+        sourceSummary: state.calendar,
+        runStartedAt,
+        runCompletedAt,
+        extraMetrics: {
+          cursor_updated: state.calendar.cursorUpdated,
+          mode: calendarJsonPath ? 'fixture' : 'live',
+        },
+      }));
     });
 
     tx();
@@ -420,6 +447,53 @@ function writeCursor(db, source, payload) {
   `).run({ source, cursor_json: JSON.stringify(payload) });
 }
 
+function buildSourceMetric({
+  runId,
+  source,
+  sourceSummary,
+  runStartedAt,
+  runCompletedAt,
+  extraMetrics,
+}) {
+  const summary = sourceSummary || {};
+  const entitiesUpserted = Number(summary.upsertedMessages || summary.upsertedEvents || 0)
+    + Number(summary.upsertedContacts || 0);
+  const linksUpserted = Number(summary.upsertedLinks || 0);
+  const chunksUpserted = entitiesUpserted;
+  const sourceError = cleanLine(summary.error || '');
+
+  return {
+    run_id: runId,
+    source,
+    status: sourceError ? 'failed' : 'ok',
+    run_started_at: runStartedAt,
+    run_completed_at: runCompletedAt,
+    records_scanned: Number(summary.scanned || 0),
+    entities_upserted: entitiesUpserted,
+    chunks_upserted: chunksUpserted,
+    links_upserted: linksUpserted,
+    error_message: sourceError || null,
+    metrics_json: JSON.stringify({
+      latest_seen_at: summary.latestSeenAt || null,
+      ...extraMetrics,
+    }),
+  };
+}
+
+function writeIngestionRunMetric(db, metric) {
+  db.prepare(`
+    INSERT INTO ingestion_run_metrics (
+      run_id, source, status, run_started_at, run_completed_at,
+      records_scanned, entities_upserted, chunks_upserted, links_upserted,
+      error_message, metrics_json
+    ) VALUES (
+      @run_id, @source, @status, @run_started_at, @run_completed_at,
+      @records_scanned, @entities_upserted, @chunks_upserted, @links_upserted,
+      @error_message, @metrics_json
+    )
+  `).run(metric);
+}
+
 async function fetchGmailMessages({ account, max, sinceIso, retryConfig }) {
   const afterEpoch = Math.floor(new Date(sinceIso).getTime() / 1000);
   const query = `after:${afterEpoch} -category:promotions -category:social`;
@@ -600,7 +674,13 @@ function loadJsonFile(file) {
 }
 
 function assertHybridSchemaReady(db) {
-  const requiredTables = ['entities', 'entity_chunks', 'entity_links', 'ingestion_cursors'];
+  const requiredTables = [
+    'entities',
+    'entity_chunks',
+    'entity_links',
+    'ingestion_cursors',
+    'ingestion_run_metrics',
+  ];
   const rows = db
     .prepare(`
       SELECT name FROM sqlite_master

--- a/scripts/db/ingest-kb-hybrid.mjs
+++ b/scripts/db/ingest-kb-hybrid.mjs
@@ -26,6 +26,7 @@ main().catch((err) => {
 async function main() {
   loadEnvLocal();
   await ensureDbDir();
+  const runStartedAt = new Date().toISOString();
 
   const targetPath = dbPath('hybrid-core.sqlite');
   const db = openSqlite(targetPath);
@@ -76,6 +77,31 @@ async function main() {
       files,
       urls,
     });
+
+    const runCompletedAt = new Date().toISOString();
+    const totalScanned = Number(summary.scanned.files || 0) + Number(summary.scanned.urls || 0);
+    const failedCount = Array.isArray(summary.failed) ? summary.failed.length : 0;
+    const status = failedCount === 0
+      ? 'ok'
+      : (summary.upserted.entities > 0 ? 'partial_failure' : 'failed');
+
+    writeIngestionRunMetric(db, {
+      run_id: crypto.randomUUID(),
+      source: 'kb_ingest',
+      status,
+      run_started_at: runStartedAt,
+      run_completed_at: runCompletedAt,
+      records_scanned: totalScanned,
+      entities_upserted: Number(summary.upserted.entities || 0),
+      chunks_upserted: Number(summary.upserted.chunks || 0),
+      links_upserted: 0,
+      error_message: failedCount ? cleanLine(summary.failed[0]?.reason || 'kb_source_failure', 300) : null,
+      metrics_json: JSON.stringify({
+        failed_sources: failedCount,
+        skipped_unchanged: Number(summary.skippedUnchanged || 0),
+      }),
+    });
+
     console.log(JSON.stringify(summary, null, 2));
   } finally {
     db.close();
@@ -306,6 +332,20 @@ function writeCursor(db, source, payload) {
   `).run({ source, cursor_json: JSON.stringify(payload) });
 }
 
+function writeIngestionRunMetric(db, metric) {
+  db.prepare(`
+    INSERT INTO ingestion_run_metrics (
+      run_id, source, status, run_started_at, run_completed_at,
+      records_scanned, entities_upserted, chunks_upserted, links_upserted,
+      error_message, metrics_json
+    ) VALUES (
+      @run_id, @source, @status, @run_started_at, @run_completed_at,
+      @records_scanned, @entities_upserted, @chunks_upserted, @links_upserted,
+      @error_message, @metrics_json
+    )
+  `).run(metric);
+}
+
 function loadSourcesFile(filePath) {
   const fullPath = path.resolve(filePath);
   const raw = fs.readFileSync(fullPath, 'utf8');
@@ -333,7 +373,13 @@ function loadSourcesFile(filePath) {
 }
 
 function assertHybridSchemaReady(db) {
-  const requiredTables = ['entities', 'entity_chunks', 'entity_links', 'ingestion_cursors'];
+  const requiredTables = [
+    'entities',
+    'entity_chunks',
+    'entity_links',
+    'ingestion_cursors',
+    'ingestion_run_metrics',
+  ];
   const rows = db
     .prepare(`
       SELECT name FROM sqlite_master


### PR DESCRIPTION
## Summary
- add migration `0003_ingestion_run_metrics.sql` introducing `ingestion_run_metrics` for per-source ingestion counters
- persist source run metrics from ingestion scripts:
  - `scripts/db/ingest-gmail-calendar-hybrid.mjs` writes rows for `gmail` and `google_calendar`
  - `scripts/db/ingest-kb-hybrid.mjs` writes row for `kb_ingest`
- extend `scripts/db/hybrid-ingestion-health.mjs` with reconciliation output (latest vs previous run) per source:
  - entity delta + entity delta %
  - chunk-per-entity ratio drift
  - link delta + link delta %
- add new threshold flags to health gate:
  - `--max-entity-delta-pct`
  - `--max-chunk-ratio-delta`
  - `--max-link-delta-pct`
- document schema + runbook updates in:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `node --check scripts/db/hybrid-ingestion-health.mjs`
- `node --check scripts/db/ingest-gmail-calendar-hybrid.mjs`
- `node --check scripts/db/ingest-kb-hybrid.mjs`
- `OPENCLAW_DB_ROOT=<temp> npm run db:hybrid:init`
- `OPENCLAW_DB_ROOT=<temp> npm run db:hybrid:ingest -- --gmail-json scripts/db/fixtures/gmail-sample.json --calendar-json scripts/db/fixtures/calendar-sample.json --account richducat@gmail.com` (run twice)
- `OPENCLAW_DB_ROOT=<temp> npm run db:hybrid:ingest:kb -- --from-file scripts/db/fixtures/kb-sources-sample.json` (run twice)
- `OPENCLAW_DB_ROOT=<temp> npm run db:hybrid:health -- --json --max-lag-hours 999 --max-seen-drift-hours 999 --max-artifact-issues 999 --max-entity-delta-pct 999 --max-chunk-ratio-delta 999 --max-link-delta-pct 999`
- forced breach check (expected exit `2`):
  - `OPENCLAW_DB_ROOT=<temp> npm run db:hybrid:health -- --json --max-entity-delta-pct 0`
- `npm run md:audit:strict`

Closes #40