### PR TITLE
feat(ci): enforce live_mode governance guardrails

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -193,16 +193,22 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_mode }}
     runs-on:
       - self-hosted
+    environment:
+      name: hybrid-live
     timeout-minutes: 30
     env:
       TZ: America/New_York
       OPENCLAW_DB_ROOT: ${{ github.workspace }}/.tmp/openclaw-db
       ACCOUNT_INPUT: ${{ inputs.account || 'richducat@gmail.com' }}
       DATE_INPUT: ${{ inputs.date || '' }}
+      USE_FIXTURES_INPUT: ${{ inputs.use_fixtures }}
       SKIP_KB_INPUT: ${{ inputs.skip_kb }}
       MAX_LAG_HOURS_INPUT: ${{ inputs.max_lag_hours || '24' }}
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
+      LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
+      TRIGGER_ACTOR: ${{ github.triggering_actor || github.actor }}
+      BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -215,6 +221,35 @@ jobs:
 
       - name: Install deps
         run: npm ci
+
+      - name: Enforce live governance policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$BRANCH_NAME" != "main" ]]; then
+            echo "live_mode is restricted to main branch dispatches (current branch: $BRANCH_NAME)"
+            exit 1
+          fi
+
+          if [[ "${USE_FIXTURES_INPUT:-false}" == "true" ]]; then
+            echo "live_mode requires use_fixtures=false."
+            exit 1
+          fi
+
+          allowed_csv="${LIVE_ALLOWED_ACTORS_INPUT}"
+          actor="$TRIGGER_ACTOR"
+
+          normalized="$(printf '%s' "$allowed_csv" | tr ',' '\n' | tr -d ' ' | sed '/^$/d')"
+          if [[ -z "$normalized" ]]; then
+            echo "HYBRID_LIVE_ALLOWED_ACTORS resolved to empty. Configure at least one allowed actor."
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$normalized" | grep -Fxq "$actor"; then
+            echo "actor $actor is not authorized for live_mode. Allowed actors: $normalized"
+            exit 1
+          fi
 
       - name: Preflight live connector checks
         shell: bash

--- a/db/README.md
+++ b/db/README.md
@@ -202,6 +202,14 @@ Runtime notes:
 - Canary lane (`schedule`, or manual with `live_mode=false`) runs on `ubuntu-latest`.
 - Live lane (manual with `live_mode=true`) runs on `self-hosted`.
 - Default scheduled behavior uses repository fixtures for deterministic checks.
+- Live governance policy (enforced before preflight/pipeline):
+  - live job binds to protected GitHub Environment `hybrid-live`
+  - live dispatch is restricted to `main` branch
+  - live dispatch rejects `use_fixtures=true`
+  - triggering actor must be present in repo variable `HYBRID_LIVE_ALLOWED_ACTORS` (comma-separated usernames; defaults to `richducat` when unset)
+- Recommended setup:
+  - configure required reviewers for Environment `hybrid-live`
+  - maintain `HYBRID_LIVE_ALLOWED_ACTORS` for approved live operators
 - Live lane enforces preflight checks before the pipeline starts:
   - `gog` is installed on the runner
   - Gmail probe succeeds for the selected account

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -197,6 +197,14 @@ Include:
   - **Live lane** (manual with `live_mode=true`) runs on `self-hosted`.
 - Default scheduled behavior remains fixture-backed deterministic canary.
 - For live-source execution, use manual dispatch with `live_mode=true` (fixtures are not used in live lane).
+- Live governance policy (enforced before preflight/pipeline):
+  - Live job binds to protected GitHub Environment `hybrid-live`.
+  - Live dispatch is restricted to `main` branch.
+  - Live dispatch rejects `use_fixtures=true`.
+  - Triggering actor must be listed in repo variable `HYBRID_LIVE_ALLOWED_ACTORS` (comma-separated usernames; defaults to `richducat` when unset).
+- Recommended environment setup:
+  - Configure required reviewers for Environment `hybrid-live` so every live run requires explicit approval.
+  - Keep `HYBRID_LIVE_ALLOWED_ACTORS` aligned with approved live operators.
 - Live lane preflight checks before running pipeline:
   - `gog` binary must exist on runner PATH
   - Gmail connectivity probe succeeds for selected `account`


### PR DESCRIPTION
## Summary
- bind run-daily-live to protected GitHub Environment hybrid-live
- add fail-fast live governance gate before preflight:
  - require main branch dispatch
  - reject use_fixtures=true in live mode
  - require triggering actor to be in HYBRID_LIVE_ALLOWED_ACTORS (default fallback richducat)
- document governance policy + setup guidance in:
  - docs/RUNBOOK_DEPLOY_GENERIC.md
  - db/README.md

## Validation
- npm run md:audit:strict
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hybrid-daily-pipeline.yml"); puts "workflow yaml parse ok"'

Closes #43
