### PR TITLE
feat(ci): expand hybrid alert routing fan-out + ET escalation windows

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -148,46 +148,27 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Alert on health-gate breach
-        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL != '' }}
+      - name: Dispatch health-gate alerts
+        if: ${{ failure() }}
         env:
           ALERT_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_WEBHOOK_URL }}
+          ALERT_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_WEBHOOK_URLS }}
+          ALERT_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ESCALATION_WEBHOOK_URL }}
+          ALERT_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_ESCALATION_WEBHOOK_URLS }}
+          ALERT_ESCALATION_WINDOWS_ET: ${{ vars.HYBRID_ALERT_ESCALATION_WINDOWS_ET || 'always' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO: ${{ github.repository }}
           BRANCH_REF: ${{ github.ref_name }}
           RUN_DATE: ${{ steps.args.outputs.run_date }}
           RUN_MODE: canary
+          ARTIFACT_LABEL: hybrid-daily-canary-${{ steps.args.outputs.run_date }}
           MAX_LAG_HOURS: ${{ env.MAX_LAG_HOURS_INPUT }}
           MAX_SEEN_DRIFT_HOURS: ${{ env.MAX_SEEN_DRIFT_HOURS_INPUT }}
           MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
         shell: bash
         run: |
           set -euo pipefail
-          payload="$(node -e '
-            const body = [
-              `:rotating_light: Hybrid daily pipeline health gate breached`,
-              `Mode: ${process.env.RUN_MODE}`,
-              `Repo: ${process.env.REPO}`,
-              `Branch: ${process.env.BRANCH_REF}`,
-              `Run date: ${process.env.RUN_DATE}`,
-              `Thresholds: lag<=${process.env.MAX_LAG_HOURS}h, drift<=${process.env.MAX_SEEN_DRIFT_HOURS}h, artifactIssues<=${process.env.MAX_ARTIFACT_ISSUES}`,
-              `Run: ${process.env.RUN_URL}`,
-              `Artifacts: hybrid-daily-${process.env.RUN_MODE}-${process.env.RUN_DATE} (see run page)`
-            ].join(`\n`);
-            process.stdout.write(JSON.stringify({ text: body }));
-          ')"
-          curl --fail --show-error --silent \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "$ALERT_WEBHOOK_URL"
-
-      - name: Alert webhook not configured
-        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL == '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Health gate breached but HYBRID_ALERT_WEBHOOK_URL is not configured. Add this repo secret to enable notifications."
+          node scripts/ci/dispatch-hybrid-alert.mjs
 
   run-daily-live:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.live_mode }}
@@ -331,43 +312,24 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Alert on health-gate breach
-        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL != '' }}
+      - name: Dispatch health-gate alerts
+        if: ${{ failure() }}
         env:
           ALERT_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_WEBHOOK_URL }}
+          ALERT_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_WEBHOOK_URLS }}
+          ALERT_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ESCALATION_WEBHOOK_URL }}
+          ALERT_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_ESCALATION_WEBHOOK_URLS }}
+          ALERT_ESCALATION_WINDOWS_ET: ${{ vars.HYBRID_ALERT_ESCALATION_WINDOWS_ET || 'always' }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO: ${{ github.repository }}
           BRANCH_REF: ${{ github.ref_name }}
           RUN_DATE: ${{ steps.args.outputs.run_date }}
           RUN_MODE: live
+          ARTIFACT_LABEL: hybrid-daily-live-${{ steps.args.outputs.run_date }}
           MAX_LAG_HOURS: ${{ env.MAX_LAG_HOURS_INPUT }}
           MAX_SEEN_DRIFT_HOURS: ${{ env.MAX_SEEN_DRIFT_HOURS_INPUT }}
           MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
         shell: bash
         run: |
           set -euo pipefail
-          payload="$(node -e '
-            const body = [
-              `:rotating_light: Hybrid daily pipeline health gate breached`,
-              `Mode: ${process.env.RUN_MODE}`,
-              `Repo: ${process.env.REPO}`,
-              `Branch: ${process.env.BRANCH_REF}`,
-              `Run date: ${process.env.RUN_DATE}`,
-              `Thresholds: lag<=${process.env.MAX_LAG_HOURS}h, drift<=${process.env.MAX_SEEN_DRIFT_HOURS}h, artifactIssues<=${process.env.MAX_ARTIFACT_ISSUES}`,
-              `Run: ${process.env.RUN_URL}`,
-              `Artifacts: hybrid-daily-${process.env.RUN_MODE}-${process.env.RUN_DATE} (see run page)`
-            ].join(`\n`);
-            process.stdout.write(JSON.stringify({ text: body }));
-          ')"
-          curl --fail --show-error --silent \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -d "$payload" \
-            "$ALERT_WEBHOOK_URL"
-
-      - name: Alert webhook not configured
-        if: ${{ failure() && secrets.HYBRID_ALERT_WEBHOOK_URL == '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Health gate breached but HYBRID_ALERT_WEBHOOK_URL is not configured. Add this repo secret to enable notifications."
+          node scripts/ci/dispatch-hybrid-alert.mjs

--- a/db/README.md
+++ b/db/README.md
@@ -222,9 +222,18 @@ Runtime notes:
     - `--max-artifact-issues 0`
 - Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
 - Optional breach alerting:
-  - configure repo secret `HYBRID_ALERT_WEBHOOK_URL`
-  - when set, a failing health gate posts a JSON payload (`text` field) containing run mode, run URL, run date, threshold settings, and artifact label
-  - when unset, the workflow logs a warning and skips outbound notification
+  - base route config:
+    - `HYBRID_ALERT_WEBHOOK_URL` (single route)
+    - `HYBRID_ALERT_WEBHOOK_URLS` (comma/newline multi-route fan-out)
+  - optional escalation route config:
+    - `HYBRID_ALERT_ESCALATION_WEBHOOK_URL`
+    - `HYBRID_ALERT_ESCALATION_WEBHOOK_URLS`
+    - `HYBRID_ALERT_ESCALATION_WINDOWS_ET` (repo variable, defaults to `always`)
+  - window format (`ET`):
+    - `always`
+    - or semicolon-delimited entries in `daySpec@HH:MM-HH:MM`
+    - examples: `mon-fri@08:00-18:00;sat@09:00-12:00`, `sun@00:00-23:59`
+  - on health-gate failure, workflow dispatches one JSON payload (`text`) to all base routes; escalation routes are included only when current ET time is inside configured escalation windows
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -218,13 +218,23 @@ Include:
     - `max_artifact_issues=0`
   - threshold breach exits `2` and fails the run (artifacts still upload because upload step uses `if: always()`)
 - Optional breach alert hook:
-  - set repo secret `HYBRID_ALERT_WEBHOOK_URL` to enable outbound notifications
-  - on health-gate failure, workflow posts a JSON payload (`text`) with:
+  - base route config:
+    - `HYBRID_ALERT_WEBHOOK_URL` (single route)
+    - `HYBRID_ALERT_WEBHOOK_URLS` (comma/newline multi-route fan-out)
+  - optional escalation route config:
+    - `HYBRID_ALERT_ESCALATION_WEBHOOK_URL`
+    - `HYBRID_ALERT_ESCALATION_WEBHOOK_URLS`
+    - `HYBRID_ALERT_ESCALATION_WINDOWS_ET` (repo variable, defaults to `always`)
+  - escalation window format (`ET`):
+    - `always`
+    - or semicolon-delimited entries in `daySpec@HH:MM-HH:MM`
+    - examples: `mon-fri@08:00-18:00;sat@09:00-12:00`, `sun@00:00-23:59`
+  - on health-gate failure, workflow posts a JSON payload (`text`) to all configured base routes and includes escalation routes only when current ET falls inside configured escalation windows. Payload includes:
     - run mode (`canary` or `live`)
     - run URL
     - run date + threshold values
     - artifact label (`hybrid-daily-<mode>-YYYY-MM-DD`)
-  - if the secret is not set, workflow logs a warning and skips notification
+  - if no webhook routes are configured, workflow logs and skips outbound notification
 
 ## 16) Hybrid retrieval query (entities + chunks)
 - Run ranked retrieval:

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+const ET_TIMEZONE = "America/New_York";
+const WEEKDAY_TO_INDEX = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function parseList(value) {
+  if (!value) return [];
+  return value
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function unique(items) {
+  return [...new Set(items)];
+}
+
+function parseRoutes(singleVar, listVar) {
+  const single = process.env[singleVar] ? [String(process.env[singleVar]).trim()] : [];
+  const list = parseList(process.env[listVar]);
+  const routes = unique([...single, ...list]).filter((url) => /^https?:\/\//i.test(url));
+  return routes;
+}
+
+function parseTimeToken(value) {
+  const match = /^(\d{2}):(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return hour * 60 + minute;
+}
+
+function expandDaySpec(daySpec) {
+  const normalized = daySpec.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "*") return [0, 1, 2, 3, 4, 5, 6];
+
+  const result = new Set();
+  for (const tokenRaw of normalized.split(",")) {
+    const token = tokenRaw.trim();
+    if (!token) continue;
+
+    if (token.includes("-")) {
+      const [startRaw, endRaw] = token.split("-");
+      const start = WEEKDAY_TO_INDEX[startRaw?.trim()];
+      const end = WEEKDAY_TO_INDEX[endRaw?.trim()];
+      if (start == null || end == null) return null;
+      let idx = start;
+      while (true) {
+        result.add(idx);
+        if (idx === end) break;
+        idx = (idx + 1) % 7;
+      }
+      continue;
+    }
+
+    const day = WEEKDAY_TO_INDEX[token];
+    if (day == null) return null;
+    result.add(day);
+  }
+  return [...result];
+}
+
+function parseEscalationWindows(raw) {
+  const value = String(raw ?? "always").trim();
+  if (!value || value.toLowerCase() === "always") {
+    return [{ days: [0, 1, 2, 3, 4, 5, 6], startMins: 0, endMins: 1440, source: "always" }];
+  }
+
+  const windows = [];
+  for (const chunkRaw of value.split(";")) {
+    const chunk = chunkRaw.trim();
+    if (!chunk) continue;
+
+    const [daySpec, timeRange] = chunk.split("@");
+    if (!daySpec || !timeRange) {
+      throw new Error(
+        `Invalid escalation window "${chunk}". Expected format: daySpec@HH:MM-HH:MM (example mon-fri@08:00-18:00).`
+      );
+    }
+
+    const days = expandDaySpec(daySpec);
+    if (!days || days.length === 0) {
+      throw new Error(`Invalid day spec "${daySpec}" in escalation windows.`);
+    }
+
+    const [startRaw, endRaw] = timeRange.split("-");
+    const startMins = parseTimeToken(startRaw || "");
+    const endMins = parseTimeToken(endRaw || "");
+    if (startMins == null || endMins == null) {
+      throw new Error(`Invalid time range "${timeRange}" in escalation windows.`);
+    }
+
+    windows.push({
+      days,
+      startMins,
+      endMins,
+      source: chunk,
+    });
+  }
+
+  if (windows.length === 0) {
+    throw new Error("Escalation windows parsed to zero entries.");
+  }
+
+  return windows;
+}
+
+function getNowEt() {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: ET_TIMEZONE,
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date());
+
+  const weekdayRaw = parts.find((part) => part.type === "weekday")?.value?.toLowerCase() || "";
+  const hour = Number(parts.find((part) => part.type === "hour")?.value || "0");
+  const minute = Number(parts.find((part) => part.type === "minute")?.value || "0");
+  const day = WEEKDAY_TO_INDEX[weekdayRaw.slice(0, 3)];
+  if (day == null) {
+    throw new Error(`Unable to parse ET weekday from formatter output: "${weekdayRaw}"`);
+  }
+
+  return {
+    day,
+    mins: hour * 60 + minute,
+    weekday: weekdayRaw.slice(0, 3),
+    hhmm: `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+  };
+}
+
+function isWindowMatch(window, nowEt) {
+  const { days, startMins, endMins } = window;
+  if (startMins === endMins) return days.includes(nowEt.day);
+
+  if (startMins < endMins) {
+    return days.includes(nowEt.day) && nowEt.mins >= startMins && nowEt.mins < endMins;
+  }
+
+  // Overnight window, e.g. 22:00-06:00.
+  const previousDay = (nowEt.day + 6) % 7;
+  const currentDayInWindow = days.includes(nowEt.day) && nowEt.mins >= startMins;
+  const carryOverInWindow = days.includes(previousDay) && nowEt.mins < endMins;
+  return currentDayInWindow || carryOverInWindow;
+}
+
+function buildAlertText({ escalationEnabled }) {
+  const mode = process.env.RUN_MODE || "unknown";
+  const repo = process.env.REPO || "unknown";
+  const branch = process.env.BRANCH_REF || "unknown";
+  const runDate = process.env.RUN_DATE || "unknown";
+  const runUrl = process.env.RUN_URL || "";
+  const artifactLabel = process.env.ARTIFACT_LABEL || `hybrid-daily-${mode}-${runDate}`;
+  const lag = process.env.MAX_LAG_HOURS || "n/a";
+  const drift = process.env.MAX_SEEN_DRIFT_HOURS || "n/a";
+  const artifactIssues = process.env.MAX_ARTIFACT_ISSUES || "n/a";
+
+  const lines = [
+    ":rotating_light: Hybrid daily pipeline health gate breached",
+    `Mode: ${mode}`,
+    `Repo: ${repo}`,
+    `Branch: ${branch}`,
+    `Run date: ${runDate}`,
+    `Thresholds: lag<=${lag}h, drift<=${drift}h, artifactIssues<=${artifactIssues}`,
+  ];
+  if (escalationEnabled) {
+    lines.push("Escalation: ACTIVE (inside configured ET window)");
+  }
+  lines.push(`Run: ${runUrl}`);
+  lines.push(`Artifacts: ${artifactLabel} (see run page)`);
+  return lines.join("\n");
+}
+
+async function postToRoute(url, payload) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Route ${url} failed with status ${response.status}. Body: ${body.slice(0, 300)}`);
+  }
+}
+
+async function main() {
+  const baseRoutes = parseRoutes("ALERT_WEBHOOK_URL", "ALERT_WEBHOOK_URLS");
+  const escalationRoutes = parseRoutes("ALERT_ESCALATION_WEBHOOK_URL", "ALERT_ESCALATION_WEBHOOK_URLS");
+  const nowEt = getNowEt();
+
+  const escalationWindows = parseEscalationWindows(process.env.ALERT_ESCALATION_WINDOWS_ET);
+  const escalationEnabled = escalationRoutes.length > 0 && escalationWindows.some((window) => isWindowMatch(window, nowEt));
+  const destinationRoutes = unique([...baseRoutes, ...(escalationEnabled ? escalationRoutes : [])]);
+
+  if (destinationRoutes.length === 0) {
+    console.log("No alert webhooks configured. Skipping outbound alert dispatch.");
+    return;
+  }
+
+  const payload = { text: buildAlertText({ escalationEnabled }) };
+  const dryRun = String(process.env.ALERT_DRY_RUN || "").toLowerCase() === "1" || String(process.env.ALERT_DRY_RUN || "").toLowerCase() === "true";
+
+  const summary = {
+    routes_total: destinationRoutes.length,
+    base_routes: baseRoutes.length,
+    escalation_routes: escalationRoutes.length,
+    escalation_enabled: escalationEnabled,
+    escalation_windows: escalationWindows.map((window) => window.source),
+    et_now: `${nowEt.weekday}@${nowEt.hhmm}`,
+    dry_run: dryRun,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (dryRun) {
+    console.log("ALERT_DRY_RUN enabled; no webhooks invoked.");
+    return;
+  }
+
+  const failures = [];
+  for (const route of destinationRoutes) {
+    try {
+      await postToRoute(route, payload);
+      console.log(`Alert sent -> ${route}`);
+    } catch (error) {
+      failures.push(String(error?.message || error));
+      console.error(`Alert failed -> ${route}: ${error?.message || error}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Alert dispatch failed for ${failures.length} route(s).`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Implements roadmap option #1 from #45 via focused implementation issue #46.

### What changed
- Added shared alert dispatcher: `scripts/ci/dispatch-hybrid-alert.mjs`
  - supports multi-route fan-out for base notifications
  - supports optional escalation routes gated by ET time windows
  - deduplicates routes and logs deterministic dispatch summary
  - skips safely when no routes are configured
- Replaced duplicated inline webhook logic in both workflow lanes with dispatcher call:
  - `.github/workflows/hybrid-daily-pipeline.yml`
  - canary and live jobs now pass a common alert context and route config
- Updated docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

### New/expanded config surface
- Base routes:
  - `HYBRID_ALERT_WEBHOOK_URL`
  - `HYBRID_ALERT_WEBHOOK_URLS`
- Escalation routes:
  - `HYBRID_ALERT_ESCALATION_WEBHOOK_URL`
  - `HYBRID_ALERT_ESCALATION_WEBHOOK_URLS`
- ET escalation windows:
  - `HYBRID_ALERT_ESCALATION_WINDOWS_ET` (repo variable, default `always`)
  - format: `daySpec@HH:MM-HH:MM;...` (example: `mon-fri@08:00-18:00;sat@09:00-12:00`)

## Validation
- `ALERT_DRY_RUN=1 node scripts/ci/dispatch-hybrid-alert.mjs` with sample route config
- `npm run md:audit:strict`
- workflow YAML parse check (`ruby -e 'require "yaml"; YAML.load_file(...)'`)

Closes #46
Refs #45