### PR TITLE
feat(ci): add live emergency stop + break-glass audit controls

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -21,6 +21,15 @@ on:
         required: true
         type: boolean
         default: false
+      break_glass:
+        description: "Override live emergency stop (requires reason)"
+        required: true
+        type: boolean
+        default: false
+      break_glass_reason:
+        description: "Required when break_glass=true; appears in live run audit logs"
+        required: false
+        default: ""
       skip_kb:
         description: "Skip KB ingestion step"
         required: true
@@ -188,6 +197,9 @@ jobs:
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
+      LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
+      BREAK_GLASS_INPUT: ${{ inputs.break_glass }}
+      BREAK_GLASS_REASON_INPUT: ${{ inputs.break_glass_reason || '' }}
       TRIGGER_ACTOR: ${{ github.triggering_actor || github.actor }}
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
@@ -230,6 +242,33 @@ jobs:
           if ! printf '%s\n' "$normalized" | grep -Fxq "$actor"; then
             echo "actor $actor is not authorized for live_mode. Allowed actors: $normalized"
             exit 1
+          fi
+
+          stop_flag="$(printf '%s' "${LIVE_EMERGENCY_STOP_INPUT:-false}" | tr '[:upper:]' '[:lower:]')"
+          break_glass_flag="$(printf '%s' "${BREAK_GLASS_INPUT:-false}" | tr '[:upper:]' '[:lower:]')"
+          reason="$(printf '%s' "${BREAK_GLASS_REASON_INPUT:-}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+
+          if [[ "$break_glass_flag" == "true" && -z "$reason" ]]; then
+            echo "break_glass=true requires a non-empty break_glass_reason."
+            exit 1
+          fi
+
+          if [[ "$stop_flag" == "true" && "$break_glass_flag" != "true" ]]; then
+            echo "HYBRID_LIVE_EMERGENCY_STOP=true blocks live_mode runs unless break_glass=true with reason."
+            exit 1
+          fi
+
+      - name: Emit live audit context
+        shell: bash
+        run: |
+          set -euo pipefail
+          break_glass_flag="$(printf '%s' "${BREAK_GLASS_INPUT:-false}" | tr '[:upper:]' '[:lower:]')"
+          reason="$(printf '%s' "${BREAK_GLASS_REASON_INPUT:-}" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+
+          if [[ "$break_glass_flag" == "true" ]]; then
+            echo "LIVE_AUDIT actor=$TRIGGER_ACTOR emergency_stop=${LIVE_EMERGENCY_STOP_INPUT:-false} break_glass=true reason=\"$reason\""
+          else
+            echo "LIVE_AUDIT actor=$TRIGGER_ACTOR emergency_stop=${LIVE_EMERGENCY_STOP_INPUT:-false} break_glass=false"
           fi
 
       - name: Preflight live connector checks

--- a/db/README.md
+++ b/db/README.md
@@ -185,6 +185,8 @@ Triggers:
   - `date`
   - `use_fixtures`
   - `live_mode`
+  - `break_glass`
+  - `break_glass_reason`
   - `skip_kb`
   - `max_lag_hours`
   - `max_seen_drift_hours`
@@ -210,9 +212,12 @@ Runtime notes:
   - live dispatch is restricted to `main` branch
   - live dispatch rejects `use_fixtures=true`
   - triggering actor must be present in repo variable `HYBRID_LIVE_ALLOWED_ACTORS` (comma-separated usernames; defaults to `richducat` when unset)
+  - repo variable `HYBRID_LIVE_EMERGENCY_STOP=true` blocks live execution unless manual dispatch sets `break_glass=true`
+  - when `break_glass=true`, `break_glass_reason` must be non-empty; workflow logs actor + emergency-stop state + reason as a live audit line
 - Recommended setup:
   - configure required reviewers for Environment `hybrid-live`
   - maintain `HYBRID_LIVE_ALLOWED_ACTORS` for approved live operators
+  - use `HYBRID_LIVE_EMERGENCY_STOP=true` during incidents/maintenance windows to freeze live runs
 - Live lane enforces preflight checks before the pipeline starts:
   - `gog` is installed on the runner
   - Gmail probe succeeds for the selected account

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -184,7 +184,7 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`)
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
@@ -203,9 +203,13 @@ Include:
   - Live dispatch is restricted to `main` branch.
   - Live dispatch rejects `use_fixtures=true`.
   - Triggering actor must be listed in repo variable `HYBRID_LIVE_ALLOWED_ACTORS` (comma-separated usernames; defaults to `richducat` when unset).
+  - Repo variable `HYBRID_LIVE_EMERGENCY_STOP=true` blocks live execution unless manual dispatch explicitly sets `break_glass=true`.
+  - When `break_glass=true`, `break_glass_reason` must be non-empty or the run fails fast.
+  - Workflow emits a `LIVE_AUDIT` log line recording actor, emergency-stop state, break-glass flag, and reason when used.
 - Recommended environment setup:
   - Configure required reviewers for Environment `hybrid-live` so every live run requires explicit approval.
   - Keep `HYBRID_LIVE_ALLOWED_ACTORS` aligned with approved live operators.
+  - Toggle `HYBRID_LIVE_EMERGENCY_STOP=true` during incident response or maintenance freezes; only use break-glass for audited emergency overrides.
 - Live lane preflight checks before running pipeline:
   - `gog` binary must exist on runner PATH
   - Gmail connectivity probe succeeds for selected `account`


### PR DESCRIPTION
## Summary
Implements option 1 from #54 via focused issue #55.

Changes:
- adds manual dispatch inputs to hybrid daily workflow:
  - `break_glass` (boolean)
  - `break_glass_reason` (string)
- extends live governance gate in `.github/workflows/hybrid-daily-pipeline.yml`:
  - enforces repo variable `HYBRID_LIVE_EMERGENCY_STOP` (`true` blocks live runs)
  - allows explicit audited override when `break_glass=true`
  - requires non-empty `break_glass_reason` when break-glass is used
- adds explicit live audit logging line (`LIVE_AUDIT`) including actor, emergency-stop state, break-glass flag, and reason when provided
- updates operator docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hybrid-daily-pipeline.yml"); puts "workflow yaml parse ok"'`
- `npm run md:audit:strict`

Closes #55