### PR TITLE
feat(ci): live approval payloading + immutable incident ledger artifacts

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -198,6 +198,7 @@ jobs:
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
       LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
+      LIVE_APPROVAL_ENVIRONMENT: hybrid-live
       BREAK_GLASS_INPUT: ${{ inputs.break_glass }}
       BREAK_GLASS_REASON_INPUT: ${{ inputs.break_glass_reason || '' }}
       TRIGGER_ACTOR: ${{ github.triggering_actor || github.actor }}
@@ -258,6 +259,43 @@ jobs:
             exit 1
           fi
 
+      - name: Build run args
+        id: args
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+
+          run_date="${DATE_INPUT}"
+          if [[ -z "$run_date" ]]; then
+            run_date="$(date +%F)"
+          fi
+
+          account="${ACCOUNT_INPUT}"
+          args=(--account "$account" --date "$run_date" --brief-out "artifacts/meeting-prep-${run_date}.md")
+
+          if [[ "${SKIP_KB_INPUT:-false}" == "true" ]]; then
+            args+=(--skip-kb)
+          fi
+
+          {
+            echo "run_date=$run_date"
+            echo "account=$account"
+            printf 'args<<EOF\n'
+            printf '%q ' "${args[@]}"
+            printf '\nEOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Export immutable live incident ledger
+        id: ledger
+        shell: bash
+        env:
+          RUN_DATE: ${{ steps.args.outputs.run_date }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/export-live-incident-ledger.mjs --out-dir artifacts
+
       - name: Emit live audit context
         shell: bash
         run: |
@@ -289,33 +327,6 @@ jobs:
 
           gog gmail messages search "newer_than:7d" --max 1 --account "${ACCOUNT_INPUT}" --json > /dev/null
           gog calendar events primary --from "${from_iso}" --to "${to_iso}" --account "${ACCOUNT_INPUT}" --json > /dev/null
-
-      - name: Build run args
-        id: args
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-
-          run_date="${DATE_INPUT}"
-          if [[ -z "$run_date" ]]; then
-            run_date="$(date +%F)"
-          fi
-
-          account="${ACCOUNT_INPUT}"
-          args=(--account "$account" --date "$run_date" --brief-out "artifacts/meeting-prep-${run_date}.md")
-
-          if [[ "${SKIP_KB_INPUT:-false}" == "true" ]]; then
-            args+=(--skip-kb)
-          fi
-
-          {
-            echo "run_date=$run_date"
-            echo "account=$account"
-            printf 'args<<EOF\n'
-            printf '%q ' "${args[@]}"
-            printf '\nEOF\n'
-          } >> "$GITHUB_OUTPUT"
 
       - name: Run daily hybrid pipeline
         shell: bash
@@ -368,6 +379,15 @@ jobs:
           MAX_LAG_HOURS: ${{ env.MAX_LAG_HOURS_INPUT }}
           MAX_SEEN_DRIFT_HOURS: ${{ env.MAX_SEEN_DRIFT_HOURS_INPUT }}
           MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
+          ALERT_APPROVAL_REQUIRED: "true"
+          ALERT_APPROVAL_ENVIRONMENT: ${{ env.LIVE_APPROVAL_ENVIRONMENT }}
+          ALERT_APPROVAL_TRIGGER_ACTOR: ${{ env.TRIGGER_ACTOR }}
+          ALERT_APPROVAL_DISPATCH_ACTOR: ${{ github.actor }}
+          ALERT_BREAK_GLASS: ${{ env.BREAK_GLASS_INPUT }}
+          ALERT_BREAK_GLASS_REASON: ${{ env.BREAK_GLASS_REASON_INPUT }}
+          ALERT_EMERGENCY_STOP: ${{ env.LIVE_EMERGENCY_STOP_INPUT }}
+          ALERT_INCIDENT_LEDGER_JSON: ${{ steps.ledger.outputs.ledger_json_path }}
+          ALERT_INCIDENT_LEDGER_MD: ${{ steps.ledger.outputs.ledger_md_path }}
         shell: bash
         run: |
           set -euo pipefail

--- a/db/README.md
+++ b/db/README.md
@@ -202,6 +202,9 @@ Artifacts:
 - `pipeline-summary-YYYY-MM-DD.json`
 - `ingestion-health-YYYY-MM-DD.md`
 - `ingestion-health-YYYY-MM-DD.json`
+- live lane only:
+  - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.json`
+  - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.md`
 - uploaded as workflow artifact with lane-specific name:
   - `hybrid-daily-canary-YYYY-MM-DD`
   - `hybrid-daily-live-YYYY-MM-DD`
@@ -247,6 +250,11 @@ Runtime notes:
     - or semicolon-delimited entries in `daySpec@HH:MM-HH:MM`
     - examples: `mon-fri@08:00-18:00;sat@09:00-12:00`, `sun@00:00-23:59`
   - on health-gate failure, workflow dispatches one JSON payload (`text`) to all base routes; escalation routes are included only when current ET time is inside configured escalation windows
+  - live-mode alerts include manual-approval context and emergency control state:
+    - approval required flag + environment
+    - triggering actor + dispatch actor
+    - emergency stop + break-glass flag/reason
+    - incident-ledger artifact paths (json + markdown)
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -194,6 +194,9 @@ Include:
   - `pipeline-summary-YYYY-MM-DD.json`
   - `ingestion-health-YYYY-MM-DD.md`
   - `ingestion-health-YYYY-MM-DD.json`
+  - live lane only:
+    - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.json`
+    - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.md`
 - Artifact names now include execution lane:
   - `hybrid-daily-canary-YYYY-MM-DD`
   - `hybrid-daily-live-YYYY-MM-DD`
@@ -243,6 +246,11 @@ Include:
     - run URL
     - run date + threshold values
     - artifact label (`hybrid-daily-<mode>-YYYY-MM-DD`)
+    - live-mode manual-approval + emergency-control context:
+      - approval-required flag + approval environment
+      - triggering actor + dispatch actor
+      - emergency stop + break-glass flag/reason
+      - incident-ledger artifact paths (json + markdown)
   - if no webhook routes are configured, workflow logs and skips outbound notification
 
 ## 16) Hybrid retrieval query (entities + chunks)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -165,6 +165,15 @@ function buildAlertText({ escalationEnabled }) {
   const lag = process.env.MAX_LAG_HOURS || "n/a";
   const drift = process.env.MAX_SEEN_DRIFT_HOURS || "n/a";
   const artifactIssues = process.env.MAX_ARTIFACT_ISSUES || "n/a";
+  const approvalRequired = String(process.env.ALERT_APPROVAL_REQUIRED || "").trim().toLowerCase();
+  const approvalEnvironment = process.env.ALERT_APPROVAL_ENVIRONMENT || "";
+  const approvalTriggeringActor = process.env.ALERT_APPROVAL_TRIGGER_ACTOR || "";
+  const approvalDispatchActor = process.env.ALERT_APPROVAL_DISPATCH_ACTOR || "";
+  const breakGlass = String(process.env.ALERT_BREAK_GLASS || "").trim().toLowerCase();
+  const breakGlassReason = process.env.ALERT_BREAK_GLASS_REASON || "";
+  const emergencyStop = String(process.env.ALERT_EMERGENCY_STOP || "").trim().toLowerCase();
+  const ledgerJson = process.env.ALERT_INCIDENT_LEDGER_JSON || "";
+  const ledgerMd = process.env.ALERT_INCIDENT_LEDGER_MD || "";
 
   const lines = [
     ":rotating_light: Hybrid daily pipeline health gate breached",
@@ -177,8 +186,26 @@ function buildAlertText({ escalationEnabled }) {
   if (escalationEnabled) {
     lines.push("Escalation: ACTIVE (inside configured ET window)");
   }
+  if (
+    approvalRequired === "true" ||
+    approvalEnvironment ||
+    approvalTriggeringActor ||
+    approvalDispatchActor ||
+    breakGlass ||
+    emergencyStop
+  ) {
+    lines.push(
+      `Approval context: required=${approvalRequired === "true" ? "true" : "unknown"}, env=${approvalEnvironment || "n/a"}, triggeringActor=${approvalTriggeringActor || "n/a"}, dispatchActor=${approvalDispatchActor || "n/a"}`
+    );
+    lines.push(
+      `Emergency controls: stop=${emergencyStop || "n/a"}, breakGlass=${breakGlass || "n/a"}, reason=${breakGlassReason || "n/a"}`
+    );
+  }
   lines.push(`Run: ${runUrl}`);
   lines.push(`Artifacts: ${artifactLabel} (see run page)`);
+  if (ledgerJson || ledgerMd) {
+    lines.push(`Incident ledger: json=${ledgerJson || "n/a"}, md=${ledgerMd || "n/a"}`);
+  }
   return lines.join("\n");
 }
 

--- a/scripts/ci/export-live-incident-ledger.mjs
+++ b/scripts/ci/export-live-incident-ledger.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = { outDir: "artifacts" };
+  for (let idx = 0; idx < argv.length; idx += 1) {
+    const token = argv[idx];
+    if (token === "--out-dir") {
+      args.outDir = String(argv[idx + 1] || "").trim() || "artifacts";
+      idx += 1;
+    } else {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+  return args;
+}
+
+function normalizeBoolean(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+function trimOrEmpty(value) {
+  return String(value || "").trim();
+}
+
+function normalizeDateToken(value) {
+  const token = trimOrEmpty(value);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(token)) return token;
+  return new Date().toISOString().slice(0, 10);
+}
+
+function writeExclusive(filePath, contents) {
+  try {
+    fs.writeFileSync(filePath, contents, { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    if (error && error.code === "EEXIST") {
+      throw new Error(`Immutable ledger write blocked: file already exists (${filePath})`);
+    }
+    throw error;
+  }
+}
+
+function appendGitHubOutput(kvPairs) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  const lines = Object.entries(kvPairs).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(outputFile, `${lines.join("\n")}\n`, "utf8");
+}
+
+function sha256(text) {
+  return crypto.createHash("sha256").update(text).digest("hex");
+}
+
+function buildLedgerEntry() {
+  const runId = trimOrEmpty(process.env.GITHUB_RUN_ID) || "unknown";
+  const runAttempt = trimOrEmpty(process.env.GITHUB_RUN_ATTEMPT) || "unknown";
+  const runDate = normalizeDateToken(process.env.RUN_DATE);
+  const breakGlass = normalizeBoolean(process.env.BREAK_GLASS_INPUT);
+  const breakGlassReason = trimOrEmpty(process.env.BREAK_GLASS_REASON_INPUT);
+
+  return {
+    schema_version: 1,
+    generated_at_utc: new Date().toISOString(),
+    run: {
+      mode: "live",
+      date: runDate,
+      id: runId,
+      attempt: runAttempt,
+      url:
+        trimOrEmpty(process.env.RUN_URL) ||
+        `https://github.com/${trimOrEmpty(process.env.GITHUB_REPOSITORY)}/actions/runs/${runId}`,
+      workflow: trimOrEmpty(process.env.GITHUB_WORKFLOW),
+      repository: trimOrEmpty(process.env.GITHUB_REPOSITORY),
+      branch: trimOrEmpty(process.env.GITHUB_REF_NAME),
+      commit_sha: trimOrEmpty(process.env.GITHUB_SHA),
+    },
+    approval_context: {
+      environment: trimOrEmpty(process.env.LIVE_APPROVAL_ENVIRONMENT) || "hybrid-live",
+      required: true,
+      triggering_actor:
+        trimOrEmpty(process.env.TRIGGER_ACTOR) || trimOrEmpty(process.env.GITHUB_TRIGGERING_ACTOR),
+      dispatch_actor: trimOrEmpty(process.env.GITHUB_ACTOR),
+      approved_actor_allowlist: trimOrEmpty(process.env.LIVE_ALLOWED_ACTORS_INPUT),
+    },
+    emergency_controls: {
+      emergency_stop: normalizeBoolean(process.env.LIVE_EMERGENCY_STOP_INPUT),
+      break_glass: breakGlass,
+      break_glass_reason: breakGlass ? breakGlassReason : "",
+    },
+  };
+}
+
+function toMarkdown(entry, entrySha256) {
+  const lines = [
+    "# Live Incident Ledger Entry",
+    "",
+    `- Entry SHA256: \`${entrySha256}\``,
+    `- Generated (UTC): \`${entry.generated_at_utc}\``,
+    `- Run mode: \`${entry.run.mode}\``,
+    `- Run date: \`${entry.run.date}\``,
+    `- Run id: \`${entry.run.id}\``,
+    `- Run attempt: \`${entry.run.attempt}\``,
+    `- Run URL: ${entry.run.url}`,
+    `- Workflow: \`${entry.run.workflow}\``,
+    `- Repository: \`${entry.run.repository}\``,
+    `- Branch: \`${entry.run.branch}\``,
+    `- Commit SHA: \`${entry.run.commit_sha}\``,
+    `- Approval environment: \`${entry.approval_context.environment}\``,
+    `- Approval required: \`${entry.approval_context.required}\``,
+    `- Triggering actor: \`${entry.approval_context.triggering_actor}\``,
+    `- Dispatch actor: \`${entry.approval_context.dispatch_actor}\``,
+    `- Approved actor allowlist: \`${entry.approval_context.approved_actor_allowlist}\``,
+    `- Emergency stop flag: \`${entry.emergency_controls.emergency_stop}\``,
+    `- Break glass: \`${entry.emergency_controls.break_glass}\``,
+    `- Break glass reason: \`${entry.emergency_controls.break_glass_reason || "n/a"}\``,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDir = path.resolve(args.outDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const runDate = normalizeDateToken(process.env.RUN_DATE);
+  const runId = trimOrEmpty(process.env.GITHUB_RUN_ID) || "unknown";
+  const runAttempt = trimOrEmpty(process.env.GITHUB_RUN_ATTEMPT) || "unknown";
+  const ledgerStem = `live-incident-ledger-${runDate}-run-${runId}-attempt-${runAttempt}`;
+
+  const entry = buildLedgerEntry();
+  const canonical = JSON.stringify(entry, null, 2);
+  const entrySha256 = sha256(canonical);
+
+  const jsonPath = path.join(outDir, `${ledgerStem}.json`);
+  const mdPath = path.join(outDir, `${ledgerStem}.md`);
+
+  const jsonOutput = `${JSON.stringify({ ...entry, entry_sha256: entrySha256 }, null, 2)}\n`;
+  const mdOutput = toMarkdown(entry, entrySha256);
+
+  writeExclusive(jsonPath, jsonOutput);
+  writeExclusive(mdPath, mdOutput);
+
+  appendGitHubOutput({
+    ledger_json_path: path.relative(process.cwd(), jsonPath),
+    ledger_md_path: path.relative(process.cwd(), mdPath),
+    ledger_entry_sha256: entrySha256,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        status: "ok",
+        json_path: path.relative(process.cwd(), jsonPath),
+        md_path: path.relative(process.cwd(), mdPath),
+        entry_sha256: entrySha256,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- add live incident-ledger exporter that emits immutable JSON + markdown artifacts per run
- wire live workflow to generate ledger artifacts and pass approval/emergency context into breach alerts
- enrich alert payload text with approval context + ledger artifact paths
- update operator docs for new live artifacts and payload fields

## Validation
- ledger exporter dry-run with synthetic run env
- workflow YAML parse check
- npm run md:audit:strict

Closes #64
