### PR TITLE
Live ops phase 3: canary-vs-live drift detector + evidence bundle

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -47,11 +47,16 @@ on:
         description: "Health gate: max artifact-derived issue count before breach"
         required: false
         default: "0"
+      max_drift_signals:
+        description: "Optional drift gate in live mode: fail when canary-vs-live drift signals exceed this count"
+        required: false
+        default: ""
   schedule:
     - cron: "20 13 * * *"
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: hybrid-daily-${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +77,7 @@ jobs:
       MAX_LAG_HOURS_INPUT: ${{ inputs.max_lag_hours || '24' }}
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
+      MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -199,6 +205,7 @@ jobs:
       MAX_LAG_HOURS_INPUT: ${{ inputs.max_lag_hours || '24' }}
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
+      MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
       LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
       LIVE_APPROVAL_ENVIRONMENT: hybrid-live
@@ -359,6 +366,82 @@ jobs:
             --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \
             | tee "artifacts/ingestion-health-${run_date}.json"
 
+      - name: Resolve same-date canary artifact baseline
+        id: canary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_DATE: ${{ steps.args.outputs.run_date }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifact_name="hybrid-daily-canary-${RUN_DATE}"
+          api="https://api.github.com/repos/${REPO}/actions/artifacts?name=${artifact_name}&per_page=100"
+          response="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" "$api")"
+
+          artifact_id="$(printf '%s' "$response" | node -e '
+            const fs = require("node:fs");
+            const data = JSON.parse(fs.readFileSync(0, "utf8"));
+            const artifacts = Array.isArray(data.artifacts) ? data.artifacts : [];
+            const active = artifacts
+              .filter((artifact) => !artifact.expired)
+              .sort((a, b) => String(b.created_at || "").localeCompare(String(a.created_at || "")));
+            process.stdout.write(active[0] ? String(active[0].id) : "");
+          ')"
+
+          if [[ -z "$artifact_id" ]]; then
+            echo "Canary baseline artifact ${artifact_name} not found. Drift check will run in baseline_unavailable mode."
+          else
+            echo "Resolved canary baseline artifact id=${artifact_id} name=${artifact_name}"
+          fi
+
+          echo "artifact_id=${artifact_id}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Download canary artifact baseline
+        if: ${{ steps.canary.outputs.artifact_id != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_ID: ${{ steps.canary.outputs.artifact_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/canary-baseline
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" \
+            -o artifacts/canary-baseline.zip
+          unzip -oq artifacts/canary-baseline.zip -d artifacts/canary-baseline
+
+      - name: Compare canary-vs-live health drift
+        id: drift
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_date="${{ steps.args.outputs.run_date }}"
+          live_json="artifacts/ingestion-health-${run_date}.json"
+          canary_json="artifacts/canary-baseline/ingestion-health-${run_date}.json"
+
+          cmd=(
+            node scripts/ci/compare-canary-live-health.mjs
+            --run-date "$run_date"
+            --live-json "$live_json"
+            --out-dir artifacts
+          )
+
+          if [[ -f "$canary_json" ]]; then
+            cmd+=(--canary-json "$canary_json")
+          fi
+
+          if [[ -n "${MAX_DRIFT_SIGNALS_INPUT:-}" ]]; then
+            cmd+=(--max-drift-signals "${MAX_DRIFT_SIGNALS_INPUT}")
+          fi
+
+          "${cmd[@]}"
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -394,6 +477,11 @@ jobs:
           ALERT_EMERGENCY_STOP: ${{ env.LIVE_EMERGENCY_STOP_INPUT }}
           ALERT_INCIDENT_LEDGER_JSON: ${{ steps.ledger.outputs.ledger_json_path }}
           ALERT_INCIDENT_LEDGER_MD: ${{ steps.ledger.outputs.ledger_md_path }}
+          ALERT_DRIFT_STATUS: ${{ steps.drift.outputs.drift_status }}
+          ALERT_DRIFT_SIGNAL_COUNT: ${{ steps.drift.outputs.drift_signal_count }}
+          ALERT_DRIFT_GATE_BREACHED: ${{ steps.drift.outputs.drift_gate_breached }}
+          ALERT_DRIFT_JSON: ${{ steps.drift.outputs.drift_json_path }}
+          ALERT_DRIFT_MD: ${{ steps.drift.outputs.drift_md_path }}
         shell: bash
         run: |
           set -euo pipefail

--- a/db/README.md
+++ b/db/README.md
@@ -200,6 +200,7 @@ Triggers:
   - `max_lag_hours`
   - `max_seen_drift_hours`
   - `max_artifact_issues`
+  - `max_drift_signals` (optional live drift gate; blank = report-only)
 
 Artifacts:
 - `meeting-prep-YYYY-MM-DD.md`
@@ -211,6 +212,8 @@ Artifacts:
 - live lane only:
   - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.json`
   - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.md`
+  - `canary-live-drift-YYYY-MM-DD.json`
+  - `canary-live-drift-YYYY-MM-DD.md`
 - uploaded as workflow artifact with lane-specific name:
   - `hybrid-daily-canary-YYYY-MM-DD`
   - `hybrid-daily-live-YYYY-MM-DD`
@@ -246,6 +249,12 @@ Runtime notes:
     - `--max-seen-drift-hours 48`
     - `--max-artifact-issues 0`
 - Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
+- Live lane also runs canary-vs-live drift comparison after health report generation:
+  - resolves latest same-date canary artifact (`hybrid-daily-canary-YYYY-MM-DD`) via GitHub Actions artifact API
+  - runs `npm run db:hybrid:drift -- --live-json ... [--canary-json ...]`
+  - emits deterministic drift evidence artifacts (`canary-live-drift-YYYY-MM-DD.{json,md}`)
+  - if canary baseline is unavailable, drift report is emitted as `status=baseline_unavailable` (non-failing report path)
+  - if `max_drift_signals` workflow input is set, drift step exits `2` when signal count exceeds that threshold
 - Optional breach alerting:
   - base route config:
     - `HYBRID_ALERT_WEBHOOK_URL` (single route)
@@ -264,6 +273,8 @@ Runtime notes:
     - triggering actor + dispatch actor
     - emergency stop + break-glass flag/reason
     - incident-ledger artifact paths (json + markdown)
+    - canary-vs-live drift summary (`status`, `signal_count`, `gate_breached`)
+    - canary-vs-live drift artifact paths (json + markdown)
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -192,7 +192,7 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`)
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
@@ -203,6 +203,8 @@ Include:
   - live lane only:
     - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.json`
     - `live-incident-ledger-YYYY-MM-DD-run-<run_id>-attempt-<run_attempt>.md`
+    - `canary-live-drift-YYYY-MM-DD.json`
+    - `canary-live-drift-YYYY-MM-DD.md`
 - Artifact names now include execution lane:
   - `hybrid-daily-canary-YYYY-MM-DD`
   - `hybrid-daily-live-YYYY-MM-DD`
@@ -237,6 +239,12 @@ Include:
     - `max_seen_drift_hours=48`
     - `max_artifact_issues=0`
   - threshold breach exits `2` and fails the run (artifacts still upload because upload step uses `if: always()`)
+- Live drift detector (live lane):
+  - resolves latest same-date canary artifact (`hybrid-daily-canary-YYYY-MM-DD`) from GitHub Actions artifacts
+  - compares canary vs live health JSON with `npm run db:hybrid:drift`
+  - always emits evidence artifacts (`canary-live-drift-YYYY-MM-DD.{json,md}`)
+  - if `max_drift_signals` input is blank, drift check is report-only
+  - if `max_drift_signals` is set, drift check exits `2` when signal count exceeds threshold
 - Optional breach alert hook:
   - base route config:
     - `HYBRID_ALERT_WEBHOOK_URL` (single route)
@@ -259,6 +267,8 @@ Include:
       - triggering actor + dispatch actor
       - emergency stop + break-glass flag/reason
       - incident-ledger artifact paths (json + markdown)
+      - canary-vs-live drift summary (`status`, `signal_count`, `gate_breached`)
+      - canary-vs-live drift artifact paths (json + markdown)
   - if no webhook routes are configured, workflow logs and skips outbound notification
 
 ## 16) Hybrid retrieval query (entities + chunks)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "db:hybrid:daily": "node scripts/db/daily-hybrid-pipeline.mjs",
     "db:hybrid:query": "node scripts/db/query-hybrid.mjs",
     "db:hybrid:health": "node scripts/db/hybrid-ingestion-health.mjs",
+    "db:hybrid:drift": "node scripts/ci/compare-canary-live-health.mjs",
     "md:audit": "node scripts/maintenance/markdown-audit.mjs",
     "md:audit:strict": "node scripts/maintenance/markdown-audit.mjs --strict"
   },

--- a/scripts/ci/compare-canary-live-health.mjs
+++ b/scripts/ci/compare-canary-live-health.mjs
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    canaryJson: "",
+    liveJson: "",
+    outDir: "artifacts",
+    runDate: "",
+    maxDriftSignals: null,
+    maxSourceLagDeltaHours: 2,
+    maxSourceSeenDriftDeltaHours: 4,
+    maxTotalsDeltaPct: 25,
+  };
+
+  for (let idx = 0; idx < argv.length; idx += 1) {
+    const token = argv[idx];
+    const next = argv[idx + 1];
+    if (token === "--canary-json") {
+      args.canaryJson = String(next || "").trim();
+      idx += 1;
+    } else if (token === "--live-json") {
+      args.liveJson = String(next || "").trim();
+      idx += 1;
+    } else if (token === "--out-dir") {
+      args.outDir = String(next || "").trim() || "artifacts";
+      idx += 1;
+    } else if (token === "--run-date") {
+      args.runDate = String(next || "").trim();
+      idx += 1;
+    } else if (token === "--max-drift-signals") {
+      const value = Number(next);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --max-drift-signals value: ${next}`);
+      }
+      args.maxDriftSignals = Math.floor(value);
+      idx += 1;
+    } else if (token === "--max-source-lag-delta-hours") {
+      const value = Number(next);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --max-source-lag-delta-hours value: ${next}`);
+      }
+      args.maxSourceLagDeltaHours = value;
+      idx += 1;
+    } else if (token === "--max-source-seen-drift-delta-hours") {
+      const value = Number(next);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --max-source-seen-drift-delta-hours value: ${next}`);
+      }
+      args.maxSourceSeenDriftDeltaHours = value;
+      idx += 1;
+    } else if (token === "--max-totals-delta-pct") {
+      const value = Number(next);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --max-totals-delta-pct value: ${next}`);
+      }
+      args.maxTotalsDeltaPct = value;
+      idx += 1;
+    } else {
+      throw new Error(`Unknown argument: ${token}`);
+    }
+  }
+
+  if (!args.liveJson) {
+    throw new Error("--live-json is required");
+  }
+  return args;
+}
+
+function toNumberOrNull(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return numeric;
+}
+
+function percentDelta(current, baseline) {
+  const c = toNumberOrNull(current);
+  const b = toNumberOrNull(baseline);
+  if (c == null || b == null) return null;
+  if (b === 0) return c === 0 ? 0 : 100;
+  return ((c - b) / Math.abs(b)) * 100;
+}
+
+function safeReadJson(filePath) {
+  const payload = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(payload);
+}
+
+function appendGitHubOutput(kvPairs) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  const lines = Object.entries(kvPairs).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(outputFile, `${lines.join("\n")}\n`, "utf8");
+}
+
+function sourceMap(doc) {
+  const entries = Array.isArray(doc?.sources) ? doc.sources : [];
+  const map = new Map();
+  for (const row of entries) {
+    const key = String(row?.source || "").trim();
+    if (!key) continue;
+    map.set(key, row);
+  }
+  return map;
+}
+
+function severityRank(level) {
+  if (level === "high") return 3;
+  if (level === "medium") return 2;
+  return 1;
+}
+
+function compare(canary, live, thresholds) {
+  const signals = [];
+  const canarySources = sourceMap(canary);
+  const liveSources = sourceMap(live);
+  const allSources = [...new Set([...canarySources.keys(), ...liveSources.keys()])].sort();
+
+  for (const source of allSources) {
+    const c = canarySources.get(source) || null;
+    const l = liveSources.get(source) || null;
+    if (!c || !l) {
+      signals.push({
+        code: "source_missing",
+        severity: "high",
+        source,
+        message: `Source "${source}" missing in ${!c ? "canary" : "live"} report.`,
+      });
+      continue;
+    }
+
+    const cStatus = String(c.status || "unknown");
+    const lStatus = String(l.status || "unknown");
+    if (cStatus !== lStatus) {
+      signals.push({
+        code: "source_status_changed",
+        severity: "medium",
+        source,
+        canary: cStatus,
+        live: lStatus,
+        message: `Source "${source}" status changed: canary=${cStatus}, live=${lStatus}.`,
+      });
+    }
+
+    const lagDelta = toNumberOrNull(l.lag_hours) != null && toNumberOrNull(c.lag_hours) != null ? Number((l.lag_hours - c.lag_hours).toFixed(3)) : null;
+    if (lagDelta != null && lagDelta > thresholds.max_source_lag_delta_hours) {
+      signals.push({
+        code: "source_lag_delta_exceeded",
+        severity: "medium",
+        source,
+        canary_lag_hours: c.lag_hours,
+        live_lag_hours: l.lag_hours,
+        lag_delta_hours: lagDelta,
+        threshold_hours: thresholds.max_source_lag_delta_hours,
+        message: `Source "${source}" lag delta ${lagDelta}h exceeds threshold ${thresholds.max_source_lag_delta_hours}h.`,
+      });
+    }
+
+    const seenDriftDelta =
+      toNumberOrNull(l.seen_drift_hours) != null && toNumberOrNull(c.seen_drift_hours) != null
+        ? Number((l.seen_drift_hours - c.seen_drift_hours).toFixed(3))
+        : null;
+    if (seenDriftDelta != null && seenDriftDelta > thresholds.max_source_seen_drift_delta_hours) {
+      signals.push({
+        code: "source_seen_drift_delta_exceeded",
+        severity: "medium",
+        source,
+        canary_seen_drift_hours: c.seen_drift_hours,
+        live_seen_drift_hours: l.seen_drift_hours,
+        seen_drift_delta_hours: seenDriftDelta,
+        threshold_hours: thresholds.max_source_seen_drift_delta_hours,
+        message: `Source "${source}" seen drift delta ${seenDriftDelta}h exceeds threshold ${thresholds.max_source_seen_drift_delta_hours}h.`,
+      });
+    }
+  }
+
+  const canaryFailures = Array.isArray(canary?.failures?.issues) ? canary.failures.issues.length : 0;
+  const liveFailures = Array.isArray(live?.failures?.issues) ? live.failures.issues.length : 0;
+  if (liveFailures > canaryFailures) {
+    signals.push({
+      code: "failure_issues_increased",
+      severity: "high",
+      canary_failures: canaryFailures,
+      live_failures: liveFailures,
+      message: `Live artifact issues (${liveFailures}) exceeded canary (${canaryFailures}).`,
+    });
+  }
+
+  const canaryBreaches = Array.isArray(canary?.breaches) ? canary.breaches.length : 0;
+  const liveBreaches = Array.isArray(live?.breaches) ? live.breaches.length : 0;
+  if (liveBreaches > canaryBreaches) {
+    signals.push({
+      code: "threshold_breaches_increased",
+      severity: "high",
+      canary_breaches: canaryBreaches,
+      live_breaches: liveBreaches,
+      message: `Live threshold breaches (${liveBreaches}) exceeded canary (${canaryBreaches}).`,
+    });
+  }
+
+  const canaryAnomalies = toNumberOrNull(canary?.baselines?.totals?.anomalies) || 0;
+  const liveAnomalies = toNumberOrNull(live?.baselines?.totals?.anomalies) || 0;
+  if (liveAnomalies > canaryAnomalies) {
+    signals.push({
+      code: "baseline_anomalies_increased",
+      severity: "medium",
+      canary_anomalies: canaryAnomalies,
+      live_anomalies: liveAnomalies,
+      message: `Live baseline anomalies (${liveAnomalies}) exceeded canary (${canaryAnomalies}).`,
+    });
+  }
+
+  const canaryEntities = toNumberOrNull(canary?.totals?.entities) || 0;
+  const liveEntities = toNumberOrNull(live?.totals?.entities) || 0;
+  const canaryChunks = toNumberOrNull(canary?.totals?.chunks) || 0;
+  const liveChunks = toNumberOrNull(live?.totals?.chunks) || 0;
+  const entityDeltaPct = percentDelta(liveEntities, canaryEntities);
+  const chunkDeltaPct = percentDelta(liveChunks, canaryChunks);
+  if (entityDeltaPct != null && Math.abs(entityDeltaPct) > thresholds.max_totals_delta_pct) {
+    signals.push({
+      code: "entity_totals_delta_exceeded",
+      severity: "medium",
+      canary_entities: canaryEntities,
+      live_entities: liveEntities,
+      entity_delta_pct: Number(entityDeltaPct.toFixed(3)),
+      threshold_pct: thresholds.max_totals_delta_pct,
+      message: `Entity totals delta ${entityDeltaPct.toFixed(2)}% exceeded threshold ${thresholds.max_totals_delta_pct}%.`,
+    });
+  }
+  if (chunkDeltaPct != null && Math.abs(chunkDeltaPct) > thresholds.max_totals_delta_pct) {
+    signals.push({
+      code: "chunk_totals_delta_exceeded",
+      severity: "medium",
+      canary_chunks: canaryChunks,
+      live_chunks: liveChunks,
+      chunk_delta_pct: Number(chunkDeltaPct.toFixed(3)),
+      threshold_pct: thresholds.max_totals_delta_pct,
+      message: `Chunk totals delta ${chunkDeltaPct.toFixed(2)}% exceeded threshold ${thresholds.max_totals_delta_pct}%.`,
+    });
+  }
+
+  const highestSeverity = signals
+    .map((signal) => signal.severity || "low")
+    .sort((left, right) => severityRank(right) - severityRank(left))[0];
+
+  return {
+    signals,
+    highest_severity: highestSeverity || "none",
+    canary_metrics: {
+      failures: canaryFailures,
+      breaches: canaryBreaches,
+      anomalies: canaryAnomalies,
+      totals: { entities: canaryEntities, chunks: canaryChunks },
+    },
+    live_metrics: {
+      failures: liveFailures,
+      breaches: liveBreaches,
+      anomalies: liveAnomalies,
+      totals: { entities: liveEntities, chunks: liveChunks },
+    },
+  };
+}
+
+function toMarkdown(report) {
+  const lines = [
+    "# Canary vs Live Drift Report",
+    "",
+    `- Status: ${report.status}`,
+    `- Generated (UTC): ${report.generated_at_utc}`,
+    `- Run date: ${report.run_date}`,
+    `- Canary baseline: ${report.inputs.canary_json || "unavailable"}`,
+    `- Live health file: ${report.inputs.live_json}`,
+    `- Signal count: ${report.summary.signal_count}`,
+    `- Highest severity: ${report.summary.highest_severity}`,
+    "",
+    "## Thresholds",
+    "",
+    `- max_source_lag_delta_hours: ${report.thresholds.max_source_lag_delta_hours}`,
+    `- max_source_seen_drift_delta_hours: ${report.thresholds.max_source_seen_drift_delta_hours}`,
+    `- max_totals_delta_pct: ${report.thresholds.max_totals_delta_pct}`,
+    `- max_drift_signals: ${report.thresholds.max_drift_signals ?? "report_only"}`,
+    "",
+  ];
+
+  if (!report.inputs.canary_json) {
+    lines.push("## Note", "", "- Canary baseline artifact for this date was not available; drift comparison skipped.");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push("## Signals", "");
+  if (!report.signals.length) {
+    lines.push("- none");
+  } else {
+    for (const signal of report.signals) {
+      lines.push(`- [${signal.severity}] ${signal.code}: ${signal.message}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDir = path.resolve(args.outDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const runDate = args.runDate || new Date().toISOString().slice(0, 10);
+  const livePath = path.resolve(args.liveJson);
+  if (!fs.existsSync(livePath)) {
+    throw new Error(`Live health JSON not found: ${livePath}`);
+  }
+  const liveDoc = safeReadJson(livePath);
+
+  const canaryPath = args.canaryJson ? path.resolve(args.canaryJson) : "";
+  const canaryAvailable = !!canaryPath && fs.existsSync(canaryPath);
+  const thresholds = {
+    max_source_lag_delta_hours: args.maxSourceLagDeltaHours,
+    max_source_seen_drift_delta_hours: args.maxSourceSeenDriftDeltaHours,
+    max_totals_delta_pct: args.maxTotalsDeltaPct,
+    max_drift_signals: args.maxDriftSignals,
+  };
+
+  const report = {
+    generated_at_utc: new Date().toISOString(),
+    run_date: runDate,
+    status: "baseline_unavailable",
+    inputs: {
+      canary_json: canaryAvailable ? path.relative(process.cwd(), canaryPath) : "",
+      live_json: path.relative(process.cwd(), livePath),
+    },
+    thresholds,
+    summary: {
+      signal_count: 0,
+      highest_severity: "none",
+      gate_breached: false,
+    },
+    signals: [],
+    metrics: {},
+  };
+
+  if (canaryAvailable) {
+    const canaryDoc = safeReadJson(canaryPath);
+    const comparison = compare(canaryDoc, liveDoc, thresholds);
+    report.signals = comparison.signals;
+    report.summary.signal_count = comparison.signals.length;
+    report.summary.highest_severity = comparison.highest_severity;
+    report.metrics = {
+      canary: comparison.canary_metrics,
+      live: comparison.live_metrics,
+    };
+    report.status = comparison.signals.length > 0 ? "drift" : "ok";
+  } else {
+    report.metrics = {
+      live: {
+        failures: Array.isArray(liveDoc?.failures?.issues) ? liveDoc.failures.issues.length : 0,
+        breaches: Array.isArray(liveDoc?.breaches) ? liveDoc.breaches.length : 0,
+        anomalies: toNumberOrNull(liveDoc?.baselines?.totals?.anomalies) || 0,
+      },
+    };
+  }
+
+  if (args.maxDriftSignals != null && report.summary.signal_count > args.maxDriftSignals) {
+    report.summary.gate_breached = true;
+  }
+
+  const stem = `canary-live-drift-${runDate}`;
+  const jsonPath = path.join(outDir, `${stem}.json`);
+  const mdPath = path.join(outDir, `${stem}.md`);
+  fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.writeFileSync(mdPath, toMarkdown(report), "utf8");
+
+  const output = {
+    status: report.status,
+    signal_count: report.summary.signal_count,
+    gate_breached: report.summary.gate_breached,
+    json_path: path.relative(process.cwd(), jsonPath),
+    md_path: path.relative(process.cwd(), mdPath),
+  };
+  appendGitHubOutput({
+    drift_status: output.status,
+    drift_signal_count: String(output.signal_count),
+    drift_gate_breached: String(output.gate_breached),
+    drift_json_path: output.json_path,
+    drift_md_path: output.md_path,
+  });
+  console.log(JSON.stringify(output, null, 2));
+
+  if (report.summary.gate_breached) {
+    process.exit(2);
+  }
+}
+
+main();

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -174,6 +174,11 @@ function buildAlertText({ escalationEnabled }) {
   const emergencyStop = String(process.env.ALERT_EMERGENCY_STOP || "").trim().toLowerCase();
   const ledgerJson = process.env.ALERT_INCIDENT_LEDGER_JSON || "";
   const ledgerMd = process.env.ALERT_INCIDENT_LEDGER_MD || "";
+  const driftStatus = process.env.ALERT_DRIFT_STATUS || "";
+  const driftSignals = process.env.ALERT_DRIFT_SIGNAL_COUNT || "";
+  const driftGateBreached = process.env.ALERT_DRIFT_GATE_BREACHED || "";
+  const driftJson = process.env.ALERT_DRIFT_JSON || "";
+  const driftMd = process.env.ALERT_DRIFT_MD || "";
 
   const lines = [
     ":rotating_light: Hybrid daily pipeline health gate breached",
@@ -205,6 +210,12 @@ function buildAlertText({ escalationEnabled }) {
   lines.push(`Artifacts: ${artifactLabel} (see run page)`);
   if (ledgerJson || ledgerMd) {
     lines.push(`Incident ledger: json=${ledgerJson || "n/a"}, md=${ledgerMd || "n/a"}`);
+  }
+  if (driftStatus || driftSignals || driftGateBreached || driftJson || driftMd) {
+    lines.push(
+      `Canary-vs-live drift: status=${driftStatus || "n/a"}, signals=${driftSignals || "n/a"}, gateBreached=${driftGateBreached || "n/a"}`
+    );
+    lines.push(`Drift evidence: json=${driftJson || "n/a"}, md=${driftMd || "n/a"}`);
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- add `scripts/ci/compare-canary-live-health.mjs` to compare same-date canary vs live ingestion health outputs
- wire live workflow lane to resolve/download latest same-date canary artifact and emit drift evidence artifacts
- add optional live gate input `max_drift_signals` (blank = report-only, set value = fail on threshold breach)
- enrich alert payload content with drift status/signal count/gate state and artifact paths
- update runbooks/docs and package script (`db:hybrid:drift`)

## Validation
- `npm run db:hybrid:drift -- --run-date 2026-04-19 --canary-json artifacts/trend-audit-test/run1.json --live-json artifacts/trend-audit-test/run2.json --out-dir artifacts/trend-audit-test`
- forced drift breach smoke: `--max-drift-signals 0` with modified live fixture (exit `2`)
- `npm run md:audit:strict`
- workflow YAML parse via Ruby

Closes #73
