### PR TITLE
feat(ci): drift taxonomy + severity-weighted live gate

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -51,6 +51,10 @@ on:
         description: "Optional drift gate in live mode: fail when canary-vs-live drift signals exceed this count"
         required: false
         default: ""
+      max_drift_severity_score:
+        description: "Optional weighted drift gate in live mode: fail when drift severity score exceeds this threshold"
+        required: false
+        default: ""
   schedule:
     - cron: "20 13 * * *"
 
@@ -78,6 +82,7 @@ jobs:
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
+      MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -206,6 +211,7 @@ jobs:
       MAX_SEEN_DRIFT_HOURS_INPUT: ${{ inputs.max_seen_drift_hours || '48' }}
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
+      MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
       LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
       LIVE_APPROVAL_ENVIRONMENT: hybrid-live
@@ -439,6 +445,9 @@ jobs:
           if [[ -n "${MAX_DRIFT_SIGNALS_INPUT:-}" ]]; then
             cmd+=(--max-drift-signals "${MAX_DRIFT_SIGNALS_INPUT}")
           fi
+          if [[ -n "${MAX_DRIFT_SEVERITY_SCORE_INPUT:-}" ]]; then
+            cmd+=(--max-drift-severity-score "${MAX_DRIFT_SEVERITY_SCORE_INPUT}")
+          fi
 
           "${cmd[@]}"
 
@@ -479,7 +488,10 @@ jobs:
           ALERT_INCIDENT_LEDGER_MD: ${{ steps.ledger.outputs.ledger_md_path }}
           ALERT_DRIFT_STATUS: ${{ steps.drift.outputs.drift_status }}
           ALERT_DRIFT_SIGNAL_COUNT: ${{ steps.drift.outputs.drift_signal_count }}
+          ALERT_DRIFT_TOTAL_SEVERITY_SCORE: ${{ steps.drift.outputs.drift_total_severity_score }}
           ALERT_DRIFT_GATE_BREACHED: ${{ steps.drift.outputs.drift_gate_breached }}
+          ALERT_DRIFT_GATE_BREACHED_BY_SIGNAL_COUNT: ${{ steps.drift.outputs.drift_gate_breached_by_signal_count }}
+          ALERT_DRIFT_GATE_BREACHED_BY_SEVERITY_SCORE: ${{ steps.drift.outputs.drift_gate_breached_by_severity_score }}
           ALERT_DRIFT_JSON: ${{ steps.drift.outputs.drift_json_path }}
           ALERT_DRIFT_MD: ${{ steps.drift.outputs.drift_md_path }}
         shell: bash

--- a/db/README.md
+++ b/db/README.md
@@ -201,6 +201,7 @@ Triggers:
   - `max_seen_drift_hours`
   - `max_artifact_issues`
   - `max_drift_signals` (optional live drift gate; blank = report-only)
+  - `max_drift_severity_score` (optional weighted live drift gate; blank = report-only)
 
 Artifacts:
 - `meeting-prep-YYYY-MM-DD.md`
@@ -255,6 +256,8 @@ Runtime notes:
   - emits deterministic drift evidence artifacts (`canary-live-drift-YYYY-MM-DD.{json,md}`)
   - if canary baseline is unavailable, drift report is emitted as `status=baseline_unavailable` (non-failing report path)
   - if `max_drift_signals` workflow input is set, drift step exits `2` when signal count exceeds that threshold
+  - if `max_drift_severity_score` workflow input is set, drift step exits `2` when severity-weight total exceeds that threshold
+  - drift signals include deterministic taxonomy fields (`category`, `severity_weight`) plus rollups (`severity_counts`, `category_counts`, `total_severity_score`)
 - Optional breach alerting:
   - base route config:
     - `HYBRID_ALERT_WEBHOOK_URL` (single route)
@@ -273,7 +276,7 @@ Runtime notes:
     - triggering actor + dispatch actor
     - emergency stop + break-glass flag/reason
     - incident-ledger artifact paths (json + markdown)
-    - canary-vs-live drift summary (`status`, `signal_count`, `gate_breached`)
+    - canary-vs-live drift summary (`status`, `signal_count`, `total_severity_score`, `gate_breached`, `gate_breached_by_signal_count`, `gate_breached_by_severity_score`)
     - canary-vs-live drift artifact paths (json + markdown)
 
 ## Retrieval/query layer (roadmap tranche option #2)

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -192,7 +192,7 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`)
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`, `max_drift_severity_score`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
@@ -245,6 +245,8 @@ Include:
   - always emits evidence artifacts (`canary-live-drift-YYYY-MM-DD.{json,md}`)
   - if `max_drift_signals` input is blank, drift check is report-only
   - if `max_drift_signals` is set, drift check exits `2` when signal count exceeds threshold
+  - if `max_drift_severity_score` is set, drift check exits `2` when severity-weighted total exceeds threshold
+  - drift output includes deterministic signal taxonomy and rollups (`category`, `severity_weight`, `severity_counts`, `category_counts`, `total_severity_score`)
 - Optional breach alert hook:
   - base route config:
     - `HYBRID_ALERT_WEBHOOK_URL` (single route)
@@ -267,7 +269,7 @@ Include:
       - triggering actor + dispatch actor
       - emergency stop + break-glass flag/reason
       - incident-ledger artifact paths (json + markdown)
-      - canary-vs-live drift summary (`status`, `signal_count`, `gate_breached`)
+      - canary-vs-live drift summary (`status`, `signal_count`, `total_severity_score`, `gate_breached`, `gate_breached_by_signal_count`, `gate_breached_by_severity_score`)
       - canary-vs-live drift artifact paths (json + markdown)
   - if no webhook routes are configured, workflow logs and skips outbound notification
 

--- a/scripts/ci/compare-canary-live-health.mjs
+++ b/scripts/ci/compare-canary-live-health.mjs
@@ -10,6 +10,7 @@ function parseArgs(argv) {
     outDir: "artifacts",
     runDate: "",
     maxDriftSignals: null,
+    maxDriftSeverityScore: null,
     maxSourceLagDeltaHours: 2,
     maxSourceSeenDriftDeltaHours: 4,
     maxTotalsDeltaPct: 25,
@@ -36,6 +37,13 @@ function parseArgs(argv) {
         throw new Error(`Invalid --max-drift-signals value: ${next}`);
       }
       args.maxDriftSignals = Math.floor(value);
+      idx += 1;
+    } else if (token === "--max-drift-severity-score") {
+      const value = Number(next);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`Invalid --max-drift-severity-score value: ${next}`);
+      }
+      args.maxDriftSeverityScore = Math.floor(value);
       idx += 1;
     } else if (token === "--max-source-lag-delta-hours") {
       const value = Number(next);
@@ -112,8 +120,43 @@ function severityRank(level) {
   return 1;
 }
 
+function severityWeight(level) {
+  if (level === "high") return 5;
+  if (level === "medium") return 3;
+  return 1;
+}
+
+function categoryForCode(code) {
+  const map = {
+    source_missing: "coverage",
+    source_status_changed: "status",
+    source_lag_delta_exceeded: "latency",
+    source_seen_drift_delta_exceeded: "cursor_freshness",
+    failure_issues_increased: "artifacts",
+    threshold_breaches_increased: "thresholds",
+    baseline_anomalies_increased: "baselines",
+    entity_totals_delta_exceeded: "volume",
+    chunk_totals_delta_exceeded: "volume",
+  };
+  return map[code] || "general";
+}
+
+function withTaxonomy(signal) {
+  const severity = String(signal?.severity || "low");
+  const code = String(signal?.code || "unknown");
+  return {
+    ...signal,
+    severity,
+    category: String(signal?.category || categoryForCode(code)),
+    severity_weight: severityWeight(severity),
+  };
+}
+
 function compare(canary, live, thresholds) {
   const signals = [];
+  function addSignal(signal) {
+    signals.push(withTaxonomy(signal));
+  }
   const canarySources = sourceMap(canary);
   const liveSources = sourceMap(live);
   const allSources = [...new Set([...canarySources.keys(), ...liveSources.keys()])].sort();
@@ -122,7 +165,7 @@ function compare(canary, live, thresholds) {
     const c = canarySources.get(source) || null;
     const l = liveSources.get(source) || null;
     if (!c || !l) {
-      signals.push({
+      addSignal({
         code: "source_missing",
         severity: "high",
         source,
@@ -134,7 +177,7 @@ function compare(canary, live, thresholds) {
     const cStatus = String(c.status || "unknown");
     const lStatus = String(l.status || "unknown");
     if (cStatus !== lStatus) {
-      signals.push({
+      addSignal({
         code: "source_status_changed",
         severity: "medium",
         source,
@@ -146,7 +189,7 @@ function compare(canary, live, thresholds) {
 
     const lagDelta = toNumberOrNull(l.lag_hours) != null && toNumberOrNull(c.lag_hours) != null ? Number((l.lag_hours - c.lag_hours).toFixed(3)) : null;
     if (lagDelta != null && lagDelta > thresholds.max_source_lag_delta_hours) {
-      signals.push({
+      addSignal({
         code: "source_lag_delta_exceeded",
         severity: "medium",
         source,
@@ -163,7 +206,7 @@ function compare(canary, live, thresholds) {
         ? Number((l.seen_drift_hours - c.seen_drift_hours).toFixed(3))
         : null;
     if (seenDriftDelta != null && seenDriftDelta > thresholds.max_source_seen_drift_delta_hours) {
-      signals.push({
+      addSignal({
         code: "source_seen_drift_delta_exceeded",
         severity: "medium",
         source,
@@ -179,7 +222,7 @@ function compare(canary, live, thresholds) {
   const canaryFailures = Array.isArray(canary?.failures?.issues) ? canary.failures.issues.length : 0;
   const liveFailures = Array.isArray(live?.failures?.issues) ? live.failures.issues.length : 0;
   if (liveFailures > canaryFailures) {
-    signals.push({
+    addSignal({
       code: "failure_issues_increased",
       severity: "high",
       canary_failures: canaryFailures,
@@ -191,7 +234,7 @@ function compare(canary, live, thresholds) {
   const canaryBreaches = Array.isArray(canary?.breaches) ? canary.breaches.length : 0;
   const liveBreaches = Array.isArray(live?.breaches) ? live.breaches.length : 0;
   if (liveBreaches > canaryBreaches) {
-    signals.push({
+    addSignal({
       code: "threshold_breaches_increased",
       severity: "high",
       canary_breaches: canaryBreaches,
@@ -203,7 +246,7 @@ function compare(canary, live, thresholds) {
   const canaryAnomalies = toNumberOrNull(canary?.baselines?.totals?.anomalies) || 0;
   const liveAnomalies = toNumberOrNull(live?.baselines?.totals?.anomalies) || 0;
   if (liveAnomalies > canaryAnomalies) {
-    signals.push({
+    addSignal({
       code: "baseline_anomalies_increased",
       severity: "medium",
       canary_anomalies: canaryAnomalies,
@@ -219,7 +262,7 @@ function compare(canary, live, thresholds) {
   const entityDeltaPct = percentDelta(liveEntities, canaryEntities);
   const chunkDeltaPct = percentDelta(liveChunks, canaryChunks);
   if (entityDeltaPct != null && Math.abs(entityDeltaPct) > thresholds.max_totals_delta_pct) {
-    signals.push({
+    addSignal({
       code: "entity_totals_delta_exceeded",
       severity: "medium",
       canary_entities: canaryEntities,
@@ -230,7 +273,7 @@ function compare(canary, live, thresholds) {
     });
   }
   if (chunkDeltaPct != null && Math.abs(chunkDeltaPct) > thresholds.max_totals_delta_pct) {
-    signals.push({
+    addSignal({
       code: "chunk_totals_delta_exceeded",
       severity: "medium",
       canary_chunks: canaryChunks,
@@ -245,9 +288,24 @@ function compare(canary, live, thresholds) {
     .map((signal) => signal.severity || "low")
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
 
+  const severity_counts = { low: 0, medium: 0, high: 0 };
+  const category_counts = {};
+  let total_severity_score = 0;
+  for (const signal of signals) {
+    if (signal.severity in severity_counts) {
+      severity_counts[signal.severity] += 1;
+    }
+    const category = signal.category || "general";
+    category_counts[category] = (category_counts[category] || 0) + 1;
+    total_severity_score += toNumberOrNull(signal.severity_weight) || 0;
+  }
+
   return {
     signals,
     highest_severity: highestSeverity || "none",
+    severity_counts,
+    category_counts,
+    total_severity_score,
     canary_metrics: {
       failures: canaryFailures,
       breaches: canaryBreaches,
@@ -273,6 +331,7 @@ function toMarkdown(report) {
     `- Canary baseline: ${report.inputs.canary_json || "unavailable"}`,
     `- Live health file: ${report.inputs.live_json}`,
     `- Signal count: ${report.summary.signal_count}`,
+    `- Total severity score: ${report.summary.total_severity_score}`,
     `- Highest severity: ${report.summary.highest_severity}`,
     "",
     "## Thresholds",
@@ -281,6 +340,7 @@ function toMarkdown(report) {
     `- max_source_seen_drift_delta_hours: ${report.thresholds.max_source_seen_drift_delta_hours}`,
     `- max_totals_delta_pct: ${report.thresholds.max_totals_delta_pct}`,
     `- max_drift_signals: ${report.thresholds.max_drift_signals ?? "report_only"}`,
+    `- max_drift_severity_score: ${report.thresholds.max_drift_severity_score ?? "report_only"}`,
     "",
   ];
 
@@ -293,8 +353,18 @@ function toMarkdown(report) {
   if (!report.signals.length) {
     lines.push("- none");
   } else {
+    lines.push(
+      `- Severity counts: high=${report.summary.severity_counts.high}, medium=${report.summary.severity_counts.medium}, low=${report.summary.severity_counts.low}`,
+    );
+    const categoryPairs = Object.entries(report.summary.category_counts || {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([category, count]) => `${category}=${count}`);
+    lines.push(`- Category counts: ${categoryPairs.length ? categoryPairs.join(", ") : "none"}`);
+    lines.push("");
     for (const signal of report.signals) {
-      lines.push(`- [${signal.severity}] ${signal.code}: ${signal.message}`);
+      lines.push(
+        `- [${signal.severity}] [${signal.category}] (weight=${signal.severity_weight}) ${signal.code}: ${signal.message}`,
+      );
     }
   }
 
@@ -320,6 +390,7 @@ function main() {
     max_source_seen_drift_delta_hours: args.maxSourceSeenDriftDeltaHours,
     max_totals_delta_pct: args.maxTotalsDeltaPct,
     max_drift_signals: args.maxDriftSignals,
+    max_drift_severity_score: args.maxDriftSeverityScore,
   };
 
   const report = {
@@ -333,8 +404,13 @@ function main() {
     thresholds,
     summary: {
       signal_count: 0,
+      total_severity_score: 0,
       highest_severity: "none",
       gate_breached: false,
+      gate_breached_by_signal_count: false,
+      gate_breached_by_severity_score: false,
+      severity_counts: { low: 0, medium: 0, high: 0 },
+      category_counts: {},
     },
     signals: [],
     metrics: {},
@@ -345,7 +421,10 @@ function main() {
     const comparison = compare(canaryDoc, liveDoc, thresholds);
     report.signals = comparison.signals;
     report.summary.signal_count = comparison.signals.length;
+    report.summary.total_severity_score = comparison.total_severity_score;
     report.summary.highest_severity = comparison.highest_severity;
+    report.summary.severity_counts = comparison.severity_counts;
+    report.summary.category_counts = comparison.category_counts;
     report.metrics = {
       canary: comparison.canary_metrics,
       live: comparison.live_metrics,
@@ -361,9 +440,12 @@ function main() {
     };
   }
 
-  if (args.maxDriftSignals != null && report.summary.signal_count > args.maxDriftSignals) {
-    report.summary.gate_breached = true;
-  }
+  report.summary.gate_breached_by_signal_count =
+    args.maxDriftSignals != null && report.summary.signal_count > args.maxDriftSignals;
+  report.summary.gate_breached_by_severity_score =
+    args.maxDriftSeverityScore != null && report.summary.total_severity_score > args.maxDriftSeverityScore;
+  report.summary.gate_breached =
+    report.summary.gate_breached_by_signal_count || report.summary.gate_breached_by_severity_score;
 
   const stem = `canary-live-drift-${runDate}`;
   const jsonPath = path.join(outDir, `${stem}.json`);
@@ -374,14 +456,20 @@ function main() {
   const output = {
     status: report.status,
     signal_count: report.summary.signal_count,
+    total_severity_score: report.summary.total_severity_score,
     gate_breached: report.summary.gate_breached,
+    gate_breached_by_signal_count: report.summary.gate_breached_by_signal_count,
+    gate_breached_by_severity_score: report.summary.gate_breached_by_severity_score,
     json_path: path.relative(process.cwd(), jsonPath),
     md_path: path.relative(process.cwd(), mdPath),
   };
   appendGitHubOutput({
     drift_status: output.status,
     drift_signal_count: String(output.signal_count),
+    drift_total_severity_score: String(output.total_severity_score),
     drift_gate_breached: String(output.gate_breached),
+    drift_gate_breached_by_signal_count: String(output.gate_breached_by_signal_count),
+    drift_gate_breached_by_severity_score: String(output.gate_breached_by_severity_score),
     drift_json_path: output.json_path,
     drift_md_path: output.md_path,
   });

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -176,7 +176,10 @@ function buildAlertText({ escalationEnabled }) {
   const ledgerMd = process.env.ALERT_INCIDENT_LEDGER_MD || "";
   const driftStatus = process.env.ALERT_DRIFT_STATUS || "";
   const driftSignals = process.env.ALERT_DRIFT_SIGNAL_COUNT || "";
+  const driftTotalSeverityScore = process.env.ALERT_DRIFT_TOTAL_SEVERITY_SCORE || "";
   const driftGateBreached = process.env.ALERT_DRIFT_GATE_BREACHED || "";
+  const driftGateBreachedBySignalCount = process.env.ALERT_DRIFT_GATE_BREACHED_BY_SIGNAL_COUNT || "";
+  const driftGateBreachedBySeverityScore = process.env.ALERT_DRIFT_GATE_BREACHED_BY_SEVERITY_SCORE || "";
   const driftJson = process.env.ALERT_DRIFT_JSON || "";
   const driftMd = process.env.ALERT_DRIFT_MD || "";
 
@@ -211,9 +214,18 @@ function buildAlertText({ escalationEnabled }) {
   if (ledgerJson || ledgerMd) {
     lines.push(`Incident ledger: json=${ledgerJson || "n/a"}, md=${ledgerMd || "n/a"}`);
   }
-  if (driftStatus || driftSignals || driftGateBreached || driftJson || driftMd) {
+  if (
+    driftStatus ||
+    driftSignals ||
+    driftTotalSeverityScore ||
+    driftGateBreached ||
+    driftGateBreachedBySignalCount ||
+    driftGateBreachedBySeverityScore ||
+    driftJson ||
+    driftMd
+  ) {
     lines.push(
-      `Canary-vs-live drift: status=${driftStatus || "n/a"}, signals=${driftSignals || "n/a"}, gateBreached=${driftGateBreached || "n/a"}`
+      `Canary-vs-live drift: status=${driftStatus || "n/a"}, signals=${driftSignals || "n/a"}, totalSeverityScore=${driftTotalSeverityScore || "n/a"}, gateBreached=${driftGateBreached || "n/a"}, gateBySignalCount=${driftGateBreachedBySignalCount || "n/a"}, gateBySeverityScore=${driftGateBreachedBySeverityScore || "n/a"}`
     );
     lines.push(`Drift evidence: json=${driftJson || "n/a"}, md=${driftMd || "n/a"}`);
   }


### PR DESCRIPTION
## Summary
- extend `scripts/ci/compare-canary-live-health.mjs` with deterministic drift taxonomy metadata per signal (`category`, `severity_weight`)
- add drift rollups to report artifacts (`severity_counts`, `category_counts`, `total_severity_score`)
- add optional weighted gate flag `--max-drift-severity-score` while preserving existing count-based gate behavior (`--max-drift-signals`)
- export additional drift outputs for workflow consumers (`drift_total_severity_score`, gate-breach split by count vs severity)
- wire workflow input `max_drift_severity_score` through live drift comparison + alert env payload
- enrich alert text with weighted drift summary/gate details
- update ops docs (`db/README.md`, `docs/RUNBOOK_DEPLOY_GENERIC.md`)

## Validation
- `npm run db:hybrid:drift -- --run-date 2026-04-19 --canary-json artifacts/trend-audit-test/run1.json --live-json artifacts/trend-audit-test/run2.json --out-dir artifacts/trend-audit-test`
- forced weighted gate breach smoke (exit `2`):
  - `npm run db:hybrid:drift -- --run-date 2026-04-19 --canary-json artifacts/trend-audit-test/run1.json --live-json artifacts/trend-audit-test/run2.weighted-breach.json --out-dir artifacts/trend-audit-test --max-drift-severity-score 0`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/hybrid-daily-pipeline.yml'); puts 'workflow yaml parse ok'"`
- `npm run md:audit:strict`

Closes #76