### PR TITLE
feat(db): weekly SLO digest artifacts + breach rollup feed

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -157,6 +157,10 @@ jobs:
             --trend-artifact-dir artifacts \
             --trend-artifact-prefix ingestion-trends \
             --trend-retention-count 180 \
+            --slo-digest-dir artifacts \
+            --slo-digest-prefix ingestion-slo-weekly \
+            --slo-window-days 7 \
+            --slo-retention-count 52 \
             --max-lag-hours "${MAX_LAG_HOURS_INPUT}" \
             --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}" \
             --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \
@@ -367,6 +371,10 @@ jobs:
             --trend-artifact-dir artifacts \
             --trend-artifact-prefix ingestion-trends \
             --trend-retention-count 180 \
+            --slo-digest-dir artifacts \
+            --slo-digest-prefix ingestion-slo-weekly \
+            --slo-window-days 7 \
+            --slo-retention-count 52 \
             --max-lag-hours "${MAX_LAG_HOURS_INPUT}" \
             --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}" \
             --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \

--- a/db/README.md
+++ b/db/README.md
@@ -332,6 +332,12 @@ Optional flags:
   - `--trend-artifact-prefix <stem>`: file prefix for exported trend artifacts (default `ingestion-trends`)
   - `--trend-retention-days <n>`: prune exported trend artifact files older than `n` days (non-negative)
   - `--trend-retention-count <n>`: keep only the newest `n` exported trend snapshots (markdown+json pair)
+- weekly SLO digest controls:
+  - `--slo-window-days <n>`: digest window size in days for snapshot + breach rollup summaries (default `7`)
+  - `--slo-digest-dir <path>`: write weekly SLO digest artifacts (`.md` + `.json`) to this directory
+  - `--slo-digest-prefix <stem>`: file prefix for exported SLO digest artifacts (default `ingestion-slo-weekly`)
+  - `--slo-retention-days <n>`: prune exported SLO digest files older than `n` days
+  - `--slo-retention-count <n>`: keep only the newest `n` exported SLO digest snapshots (markdown+json pair)
 - threshold guards (optional, non-zero exit when breached):
   - `--max-lag-hours <n>`
   - `--max-seen-drift-hours <n>`
@@ -349,6 +355,10 @@ npm run db:hybrid:health -- \
   --trend-artifact-prefix ingestion-trends \
   --trend-retention-days 90 \
   --trend-retention-count 120 \
+  --slo-digest-dir artifacts/slo-digests \
+  --slo-digest-prefix ingestion-slo-weekly \
+  --slo-window-days 7 \
+  --slo-retention-count 52 \
   --max-lag-hours 24 \
   --max-seen-drift-hours 48 \
   --max-artifact-issues 0
@@ -378,5 +388,13 @@ Output includes:
 - source-level trend summaries from persisted baseline snapshots:
   - anomaly count direction (`up`/`down`/`flat`) versus oldest snapshot in window
   - directional deltas for `records_scanned`, `entities_upserted`, `links_upserted`
+- weekly SLO digest summary from persisted baseline snapshots:
+  - window coverage (`window_start`, `window_end`, `window_days`)
+  - source-level anomaly-free coverage and anomaly rates
+  - source-level average/latest anomaly counts
+- breach rollup feed for digest window:
+  - scans `ingestion-trends-*.json` and `ingestion-health-*.json`
+  - aggregates breach events by severity and source/top breach kinds
 - threshold metadata (`thresholds`) and explicit breach records (`breaches`)
 - trend artifact export metadata (`trend_artifacts`) with written/pruned file paths when enabled
+- weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned file paths when enabled

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -236,7 +236,9 @@ Include:
   - runs `db:hybrid:health` after `db:hybrid:daily`
   - emits both markdown and JSON health artifacts
   - exports deterministic trend audit artifacts in `artifacts/` (`--trend-artifact-dir artifacts --trend-artifact-prefix ingestion-trends`)
+  - exports weekly SLO digest artifacts in `artifacts/` (`--slo-digest-dir artifacts --slo-digest-prefix ingestion-slo-weekly --slo-window-days 7`)
   - keeps trend artifacts bounded in CI lane by count (`--trend-retention-count 180`)
+  - keeps SLO digest artifacts bounded in CI lane by count (`--slo-retention-count 52`)
   - default breach thresholds:
     - `max_lag_hours=24`
     - `max_seen_drift_hours=48`
@@ -311,6 +313,12 @@ Include:
     - `--trend-artifact-prefix <stem>` file prefix for exported trend artifacts (default `ingestion-trends`)
     - `--trend-retention-days <n>` prunes exported trend artifacts older than `n` days
     - `--trend-retention-count <n>` keeps only the newest `n` exported trend snapshots (markdown+json pair)
+  - weekly SLO digest controls:
+    - `--slo-window-days <n>` digest window in days for snapshot + breach rollup summaries (default `7`)
+    - `--slo-digest-dir <path>` writes weekly SLO digest artifacts (`.md` + `.json`)
+    - `--slo-digest-prefix <stem>` file prefix for exported SLO digest artifacts (default `ingestion-slo-weekly`)
+    - `--slo-retention-days <n>` prunes exported SLO digest artifacts older than `n` days
+    - `--slo-retention-count <n>` keeps only the newest `n` exported SLO digest snapshots (markdown+json pair)
   - threshold guards (non-zero exit on breach):
     - `--max-lag-hours <n>`
     - `--max-seen-drift-hours <n>`
@@ -337,8 +345,15 @@ Include:
   - source trend summaries from persisted baseline snapshots:
     - anomaly direction and deltas versus oldest snapshot in configured window
     - directional metric deltas for records/entities/links
+  - weekly SLO digest from persisted baseline snapshots:
+    - digest window summary + source-level anomaly-free coverage
+    - source-level average/latest anomaly counts
+  - breach rollup feed for digest window:
+    - scans `ingestion-trends-*.json` and `ingestion-health-*.json`
+    - aggregates breach events by severity and source/top breach kinds
   - threshold metadata + explicit breach records in JSON mode
   - trend artifact export metadata (`trend_artifacts`) with written/pruned files when export is enabled
+  - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned files when export is enabled
 
 CI/alerting example:
 ```bash
@@ -348,6 +363,10 @@ npm run db:hybrid:health -- \
   --trend-artifact-prefix ingestion-trends \
   --trend-retention-days 90 \
   --trend-retention-count 120 \
+  --slo-digest-dir artifacts/slo-digests \
+  --slo-digest-prefix ingestion-slo-weekly \
+  --slo-window-days 7 \
+  --slo-retention-count 52 \
   --max-lag-hours 24 \
   --max-seen-drift-hours 48 \
   --max-artifact-issues 0

--- a/scripts/db/hybrid-ingestion-health.mjs
+++ b/scripts/db/hybrid-ingestion-health.mjs
@@ -16,6 +16,11 @@ const trendArtifactDirArg = getArg(args, '--trend-artifact-dir');
 const trendArtifactPrefix = sanitizeFileStem(getArg(args, '--trend-artifact-prefix') || 'ingestion-trends');
 const trendRetentionDays = readOptionalNumberArg(args, '--trend-retention-days');
 const trendRetentionCount = readOptionalNumberArg(args, '--trend-retention-count');
+const sloDigestDirArg = getArg(args, '--slo-digest-dir');
+const sloDigestPrefix = sanitizeFileStem(getArg(args, '--slo-digest-prefix') || 'ingestion-slo-weekly');
+const sloWindowDays = toSafeInt(getArg(args, '--slo-window-days'), 7, 2, 90);
+const sloRetentionDays = readOptionalNumberArg(args, '--slo-retention-days');
+const sloRetentionCount = readOptionalNumberArg(args, '--slo-retention-count');
 const baselineConfig = {
   window_runs: toSafeInt(getArg(args, '--baseline-window-runs'), 14, 3, 180),
   min_samples: toSafeInt(getArg(args, '--baseline-min-samples'), 5, 2, 50),
@@ -65,6 +70,11 @@ async function main() {
     const trends = readBaselineTrends(db, {
       window_snapshots: trendWindowSnapshots,
     });
+    const sloDigest = buildWeeklySloDigest(db, {
+      asOf,
+      windowDays: sloWindowDays,
+      artifactDirInput: artifactDirArg,
+    });
     const breaches = evaluateThresholdBreaches({
       sources: sourceHealth,
       failures: failureSummary,
@@ -89,12 +99,16 @@ async function main() {
       trend_config: {
         window_snapshots: trendWindowSnapshots,
       },
+      slo_config: {
+        window_days: sloWindowDays,
+      },
       baseline_config: baselineConfig,
       thresholds: {
         configured: hasThresholds,
         ...thresholds,
       },
       breaches,
+      slo_digest: sloDigest,
     };
 
     const trendArtifacts = exportTrendArtifacts(result, {
@@ -104,6 +118,12 @@ async function main() {
       retentionCount: trendRetentionCount,
     });
     result.trend_artifacts = trendArtifacts;
+    result.slo_digest_artifacts = exportSloDigestArtifacts(result, {
+      dirArg: sloDigestDirArg,
+      prefix: sloDigestPrefix,
+      retentionDays: sloRetentionDays,
+      retentionCount: sloRetentionCount,
+    });
 
     if (jsonMode) {
       console.log(JSON.stringify(result, null, 2));
@@ -392,6 +412,35 @@ function printMarkdown(result, artifactDirInput) {
   }
   console.log('');
 
+  console.log('## Weekly SLO Digest');
+  if (!result.slo_digest?.available) {
+    console.log(`- ${result.slo_digest?.note || 'weekly SLO digest unavailable'}`);
+  } else {
+    console.log(`- window_start=${result.slo_digest.window_start}, window_end=${result.slo_digest.window_end}, window_days=${result.slo_config?.window_days}`);
+    console.log(`- total_snapshots=${result.slo_digest.total_snapshots}, healthy_snapshots=${result.slo_digest.healthy_snapshots}, anomaly_snapshots=${result.slo_digest.anomaly_snapshots}`);
+    for (const source of result.slo_digest.sources || []) {
+      console.log(`- ${source.source}: snapshots=${source.snapshots}, healthy=${source.healthy_snapshots}, anomaly=${source.anomaly_snapshots}, anomaly_free_pct=${formatNumber(source.anomaly_free_pct)}, avg_anomalies=${formatNumber(source.avg_anomaly_count)}, latest_anomalies=${formatNumber(source.latest_anomaly_count)}, latest_health_run_at=${source.latest_health_run_at || 'n/a'}`);
+    }
+  }
+  console.log('');
+
+  console.log('## Breach Rollup Feed');
+  if (!result.slo_digest?.available) {
+    console.log('- breach rollup unavailable (SLO digest unavailable)');
+  } else if (!result.slo_digest?.breach_rollup?.total_events) {
+    console.log('- no breach events found in digest window');
+  } else {
+    console.log(`- total_events=${result.slo_digest.breach_rollup.total_events}, scanned_artifacts=${result.slo_digest.breach_rollup.scanned_artifacts}`);
+    for (const severity of result.slo_digest.breach_rollup.by_severity || []) {
+      console.log(`- severity=${severity.severity}: count=${severity.count}`);
+    }
+    for (const source of result.slo_digest.breach_rollup.by_source || []) {
+      const topKinds = (source.top_kinds || []).map((k) => `${k.kind}:${k.count}`).join(', ');
+      console.log(`- source=${source.source}: count=${source.count}, top_kinds=${topKinds || 'n/a'}`);
+    }
+  }
+  console.log('');
+
   console.log('## Trend Artifact Export');
   if (!result.trend_artifacts?.enabled) {
     console.log(`- ${result.trend_artifacts?.note || 'trend artifact export disabled'}`);
@@ -407,6 +456,30 @@ function printMarkdown(result, artifactDirInput) {
 
     if (result.trend_artifacts.pruned?.length) {
       for (const file of result.trend_artifacts.pruned) {
+        const reason = file.reason ? ` reason=${file.reason}` : '';
+        console.log(`- [pruned] ${file.file}${reason}`);
+      }
+    } else {
+      console.log('- no files pruned');
+    }
+  }
+  console.log('');
+
+  console.log('## SLO Digest Artifact Export');
+  if (!result.slo_digest_artifacts?.enabled) {
+    console.log(`- ${result.slo_digest_artifacts?.note || 'SLO digest artifact export disabled'}`);
+  } else {
+    console.log(`- artifact_dir=${result.slo_digest_artifacts.artifact_dir}`);
+    if (result.slo_digest_artifacts.written?.length) {
+      for (const file of result.slo_digest_artifacts.written) {
+        console.log(`- [written] ${file.file}`);
+      }
+    } else {
+      console.log('- no files written');
+    }
+
+    if (result.slo_digest_artifacts.pruned?.length) {
+      for (const file of result.slo_digest_artifacts.pruned) {
         const reason = file.reason ? ` reason=${file.reason}` : '';
         console.log(`- [pruned] ${file.file}${reason}`);
       }
@@ -1212,6 +1285,177 @@ function exportTrendArtifacts(result, options) {
   };
 }
 
+function buildWeeklySloDigest(db, { asOf, windowDays, artifactDirInput }) {
+  if (!tableExists(db, 'ingestion_baseline_snapshots')) {
+    return {
+      available: false,
+      note: 'ingestion_baseline_snapshots table missing (run npm run db:hybrid:init)',
+    };
+  }
+
+  const windowEnd = asOf.toISOString();
+  const windowStartDate = new Date(asOf.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const windowStart = windowStartDate.toISOString();
+
+  const rows = db.prepare(`
+    SELECT source, health_run_at, anomaly_count
+    FROM ingestion_baseline_snapshots
+    WHERE source IN (${DEFAULT_SOURCES.map(() => '?').join(',')})
+      AND health_run_at >= ?
+      AND health_run_at <= ?
+    ORDER BY source ASC, health_run_at DESC
+  `).all(...DEFAULT_SOURCES, windowStart, windowEnd);
+
+  const grouped = new Map();
+  for (const row of rows) {
+    const source = String(row.source);
+    if (!grouped.has(source)) grouped.set(source, []);
+    grouped.get(source).push({
+      health_run_at: toIsoOrNull(row.health_run_at),
+      anomaly_count: Number(row.anomaly_count || 0),
+    });
+  }
+
+  const sources = DEFAULT_SOURCES.map((source) => {
+    const history = grouped.get(source) || [];
+    const snapshots = history.length;
+    const anomalySnapshots = history.filter((row) => Number(row.anomaly_count || 0) > 0).length;
+    const healthySnapshots = snapshots - anomalySnapshots;
+    const avgAnomalyCount = snapshots
+      ? Number((history.reduce((sum, row) => sum + Number(row.anomaly_count || 0), 0) / snapshots).toFixed(3))
+      : null;
+    const latestAnomalyCount = snapshots ? Number(history[0].anomaly_count || 0) : null;
+
+    return {
+      source,
+      snapshots,
+      healthy_snapshots: healthySnapshots,
+      anomaly_snapshots: anomalySnapshots,
+      anomaly_free_pct: snapshots ? Number(((healthySnapshots / snapshots) * 100).toFixed(3)) : null,
+      avg_anomaly_count: avgAnomalyCount,
+      latest_anomaly_count: latestAnomalyCount,
+      latest_health_run_at: history[0]?.health_run_at || null,
+    };
+  });
+
+  const totalSnapshots = sources.reduce((sum, source) => sum + source.snapshots, 0);
+  const healthySnapshots = sources.reduce((sum, source) => sum + source.healthy_snapshots, 0);
+  const anomalySnapshots = sources.reduce((sum, source) => sum + source.anomaly_snapshots, 0);
+
+  const breachRollup = readBreachRollupFeed({
+    artifactDirInput,
+    windowStart,
+    windowEnd,
+  });
+
+  return {
+    available: true,
+    note: totalSnapshots ? null : 'no baseline snapshots found in digest window',
+    window_start: windowStart,
+    window_end: windowEnd,
+    total_snapshots: totalSnapshots,
+    healthy_snapshots: healthySnapshots,
+    anomaly_snapshots: anomalySnapshots,
+    anomaly_free_pct: totalSnapshots ? Number(((healthySnapshots / totalSnapshots) * 100).toFixed(3)) : null,
+    sources,
+    breach_rollup: breachRollup,
+  };
+}
+
+function readBreachRollupFeed({ artifactDirInput, windowStart, windowEnd }) {
+  const artifactDir = path.resolve(artifactDirInput || 'artifacts');
+  if (!fs.existsSync(artifactDir)) {
+    return {
+      total_events: 0,
+      scanned_artifacts: 0,
+      by_severity: [],
+      by_source: [],
+      note: 'artifact directory not found',
+    };
+  }
+
+  const startMs = Date.parse(windowStart);
+  const endMs = Date.parse(windowEnd);
+  const candidates = fs.readdirSync(artifactDir)
+    .filter((name) => /^ingestion-(trends|health)-.*\.json$/i.test(name))
+    .sort((a, b) => a.localeCompare(b));
+
+  const events = [];
+  let scanned = 0;
+  for (const name of candidates) {
+    const fullPath = path.join(artifactDir, name);
+    const parsed = safeJson(readTextFile(fullPath));
+    if (!parsed || typeof parsed !== 'object') continue;
+
+    const ts = toIsoOrNull(parsed.generated_at || parsed.as_of);
+    if (!ts) continue;
+    const tsMs = Date.parse(ts);
+    if (!Number.isFinite(tsMs) || tsMs < startMs || tsMs > endMs) continue;
+
+    scanned += 1;
+    const breaches = Array.isArray(parsed.breaches) ? parsed.breaches : [];
+    for (const breach of breaches) {
+      const kind = String(breach?.kind || 'unknown');
+      const source = String(breach?.source || 'global');
+      events.push({
+        occurred_at: ts,
+        source,
+        kind,
+        severity: severityForBreachKind(kind),
+      });
+    }
+  }
+
+  const severityCounts = new Map();
+  const sourceCounts = new Map();
+  for (const event of events) {
+    severityCounts.set(event.severity, (severityCounts.get(event.severity) || 0) + 1);
+    if (!sourceCounts.has(event.source)) {
+      sourceCounts.set(event.source, { source: event.source, count: 0, kinds: new Map() });
+    }
+    const bucket = sourceCounts.get(event.source);
+    bucket.count += 1;
+    bucket.kinds.set(event.kind, (bucket.kinds.get(event.kind) || 0) + 1);
+  }
+
+  const bySeverity = ['high', 'medium', 'low']
+    .map((severity) => ({
+      severity,
+      count: Number(severityCounts.get(severity) || 0),
+    }))
+    .filter((row) => row.count > 0);
+
+  const bySource = Array.from(sourceCounts.values())
+    .map((bucket) => ({
+      source: bucket.source,
+      count: bucket.count,
+      top_kinds: Array.from(bucket.kinds.entries())
+        .map(([kind, count]) => ({ kind, count }))
+        .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind))
+        .slice(0, 5),
+    }))
+    .sort((a, b) => b.count - a.count || a.source.localeCompare(b.source));
+
+  return {
+    total_events: events.length,
+    scanned_artifacts: scanned,
+    by_severity: bySeverity,
+    by_source: bySource,
+    note: events.length ? null : 'no breaches found in scanned digest window artifacts',
+  };
+}
+
+function severityForBreachKind(kind) {
+  const k = String(kind || '').toLowerCase();
+  if (['lag_hours', 'seen_drift_hours', 'baseline_anomalies_count', 'reconciliation_unavailable'].includes(k)) {
+    return 'high';
+  }
+  if (['entity_delta_pct', 'chunk_ratio_delta', 'link_delta_pct', 'artifact_issues_count'].includes(k)) {
+    return 'medium';
+  }
+  return 'low';
+}
+
 function buildTrendArtifactPayload(result) {
   return {
     generated_at: result.as_of,
@@ -1233,6 +1477,113 @@ function buildTrendArtifactPayload(result) {
     thresholds: result.thresholds || null,
     breaches: result.breaches || [],
   };
+}
+
+function exportSloDigestArtifacts(result, options) {
+  const dirArg = options?.dirArg;
+  if (!dirArg) {
+    return {
+      enabled: false,
+      note: 'set --slo-digest-dir to enable weekly SLO digest artifact export',
+    };
+  }
+
+  const artifactDir = path.resolve(dirArg);
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  const stamped = toStamp(result.as_of);
+  const stem = `${options.prefix}-${stamped}`;
+  const jsonFile = `${stem}.json`;
+  const mdFile = `${stem}.md`;
+  const jsonPath = path.join(artifactDir, jsonFile);
+  const mdPath = path.join(artifactDir, mdFile);
+
+  const payload = buildSloDigestArtifactPayload(result);
+  fs.writeFileSync(jsonPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(mdPath, `${buildSloDigestArtifactMarkdown(payload)}\n`, 'utf8');
+
+  const pruned = pruneTrendArtifacts({
+    artifactDir,
+    prefix: options.prefix,
+    retentionDays: options.retentionDays,
+    retentionCount: options.retentionCount,
+  });
+
+  return {
+    enabled: true,
+    note: null,
+    artifact_dir: artifactDir,
+    written: [
+      { file: jsonFile, path: jsonPath },
+      { file: mdFile, path: mdPath },
+    ],
+    retention: {
+      days: options.retentionDays,
+      count: options.retentionCount,
+    },
+    pruned,
+  };
+}
+
+function buildSloDigestArtifactPayload(result) {
+  return {
+    generated_at: result.as_of,
+    db: result.db,
+    slo_config: result.slo_config || null,
+    digest: result.slo_digest || null,
+  };
+}
+
+function buildSloDigestArtifactMarkdown(payload) {
+  const digest = payload.digest || {};
+  const lines = [];
+  lines.push('# Weekly SLO Digest');
+  lines.push('');
+  lines.push(`- generated_at: ${payload.generated_at}`);
+  lines.push(`- db: ${payload.db}`);
+  lines.push(`- window_start: ${digest.window_start || 'n/a'}`);
+  lines.push(`- window_end: ${digest.window_end || 'n/a'}`);
+  lines.push(`- window_days: ${payload.slo_config?.window_days ?? 'n/a'}`);
+  lines.push(`- total_snapshots: ${digest.total_snapshots ?? 0}`);
+  lines.push(`- healthy_snapshots: ${digest.healthy_snapshots ?? 0}`);
+  lines.push(`- anomaly_snapshots: ${digest.anomaly_snapshots ?? 0}`);
+  lines.push(`- anomaly_free_pct: ${formatNumber(digest.anomaly_free_pct)}`);
+  lines.push('');
+
+  lines.push('## Sources');
+  const sources = Array.isArray(digest.sources) ? digest.sources : [];
+  if (!sources.length) {
+    lines.push('- no source snapshots in window');
+  } else {
+    for (const source of sources) {
+      lines.push(`- ${source.source}: snapshots=${source.snapshots}, healthy=${source.healthy_snapshots}, anomaly=${source.anomaly_snapshots}, anomaly_free_pct=${formatNumber(source.anomaly_free_pct)}, avg_anomaly_count=${formatNumber(source.avg_anomaly_count)}, latest_anomaly_count=${formatNumber(source.latest_anomaly_count)}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Breach Rollup');
+  const rollup = digest.breach_rollup || {};
+  lines.push(`- total_events: ${rollup.total_events ?? 0}`);
+  lines.push(`- scanned_artifacts: ${rollup.scanned_artifacts ?? 0}`);
+  const bySeverity = Array.isArray(rollup.by_severity) ? rollup.by_severity : [];
+  if (!bySeverity.length) {
+    lines.push('- severities: none');
+  } else {
+    for (const row of bySeverity) {
+      lines.push(`- severity=${row.severity}: count=${row.count}`);
+    }
+  }
+  const bySource = Array.isArray(rollup.by_source) ? rollup.by_source : [];
+  if (!bySource.length) {
+    lines.push('- sources: none');
+  } else {
+    for (const row of bySource) {
+      const topKinds = (row.top_kinds || []).map((k) => `${k.kind}:${k.count}`).join(', ');
+      lines.push(`- source=${row.source}: count=${row.count}, top_kinds=${topKinds || 'n/a'}`);
+    }
+  }
+
+  return lines.join('\n');
 }
 
 function buildTrendArtifactMarkdown(payload) {


### PR DESCRIPTION
## Summary
- extend `scripts/db/hybrid-ingestion-health.mjs` with weekly SLO digest generation from persisted baseline snapshots
- add breach rollup feed aggregation over digest window (severity/source/top breach kinds from historical health/trend artifacts)
- add optional weekly SLO artifact export + retention controls:
  - `--slo-digest-dir`
  - `--slo-digest-prefix`
  - `--slo-window-days`
  - `--slo-retention-days`
  - `--slo-retention-count`
- expose digest + rollup sections in markdown and JSON output contracts
- wire CI health-gate step to emit SLO digest artifacts in workflow artifacts
- update docs (`db/README.md`, `docs/RUNBOOK_DEPLOY_GENERIC.md`)

## Validation
- `npm run db:hybrid:init`
- `npm run db:hybrid:health`
- `node scripts/db/hybrid-ingestion-health.mjs --json --artifact-dir artifacts --trend-artifact-dir artifacts/trend-audit-test --trend-retention-count 5 --slo-digest-dir artifacts/slo-digest-test --slo-window-days 7 --slo-retention-count 5 --max-lag-hours 999 --max-seen-drift-hours 999 --max-artifact-issues 999 --max-baseline-anomalies 999`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/hybrid-daily-pipeline.yml'); puts 'workflow yaml parse ok'"`
- `npm run md:audit:strict`

Closes #82