### PR TITLE
feat(ci): live ops phase 7 ACK evidence ingestion + stale expiry

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -176,6 +176,24 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Ingest ACK evidence
+        if: ${{ failure() }}
+        id: ack_evidence
+        env:
+          ALERT_ACK_EVIDENCE_MARKERS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_MARKERS || '' }}
+          ALERT_ACK_EVIDENCE_KEYS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_KEYS || '' }}
+          ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES || '10080' }}
+          RUN_DATE: ${{ steps.args.outputs.run_date }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/ack-evidence
+          node scripts/ci/ingest-ack-evidence.mjs \
+            --run-date "${RUN_DATE}" \
+            --out-dir artifacts \
+            --evidence-dir artifacts/ack-evidence \
+            --stale-after-minutes "${ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES}"
+
       - name: Dispatch health-gate alerts
         if: ${{ failure() }}
         env:
@@ -195,8 +213,10 @@ jobs:
           ALERT_ACK_SLA_MINUTES: ${{ vars.HYBRID_ALERT_ACK_SLA_MINUTES || '' }}
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
-          ALERT_ACK_EVIDENCE_MARKERS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_MARKERS || '' }}
-          ALERT_ACK_EVIDENCE_KEYS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_KEYS || '' }}
+          ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
+          ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
+          ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}
+          ALERT_ACK_STALE_AFTER_MINUTES: ${{ vars.HYBRID_ALERT_ACK_STALE_AFTER_MINUTES || '1440' }}
           ALERT_ACK_STATE_PATH: artifacts/ack-state-canary.json
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO: ${{ github.repository }}
@@ -484,6 +504,24 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Ingest ACK evidence
+        if: ${{ failure() }}
+        id: ack_evidence
+        env:
+          ALERT_ACK_EVIDENCE_MARKERS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_MARKERS || '' }}
+          ALERT_ACK_EVIDENCE_KEYS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_KEYS || '' }}
+          ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES || '10080' }}
+          RUN_DATE: ${{ steps.args.outputs.run_date }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/ack-evidence
+          node scripts/ci/ingest-ack-evidence.mjs \
+            --run-date "${RUN_DATE}" \
+            --out-dir artifacts \
+            --evidence-dir artifacts/ack-evidence \
+            --stale-after-minutes "${ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES}"
+
       - name: Dispatch health-gate alerts
         if: ${{ failure() }}
         env:
@@ -503,8 +541,10 @@ jobs:
           ALERT_ACK_SLA_MINUTES: ${{ vars.HYBRID_ALERT_ACK_SLA_MINUTES || '' }}
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
-          ALERT_ACK_EVIDENCE_MARKERS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_MARKERS || '' }}
-          ALERT_ACK_EVIDENCE_KEYS: ${{ vars.HYBRID_ALERT_ACK_EVIDENCE_KEYS || '' }}
+          ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
+          ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
+          ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}
+          ALERT_ACK_STALE_AFTER_MINUTES: ${{ vars.HYBRID_ALERT_ACK_STALE_AFTER_MINUTES || '1440' }}
           ALERT_ACK_STATE_PATH: ${{ github.workspace }}/.tmp/openclaw-db/live-ack-state.json
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO: ${{ github.repository }}

--- a/db/README.md
+++ b/db/README.md
@@ -294,6 +294,17 @@ Runtime notes:
     - `HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS` (default `2`)
     - `HYBRID_ALERT_ACK_EVIDENCE_MARKERS` (comma/newline/JSON-array list of acknowledged markers)
     - `HYBRID_ALERT_ACK_EVIDENCE_KEYS` (comma/newline/JSON-array list of acknowledged incident keys)
+    - `HYBRID_ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES` (default `10080`; evidence entries older than this are ignored during ingestion)
+    - `HYBRID_ALERT_ACK_STALE_AFTER_MINUTES` (default `1440`; pending incidents not seen within this window are marked `stale` and removed from reminder routing)
+  - optional ACK evidence ingestion directory:
+    - workflow reads `artifacts/ack-evidence/*.json` on failure and merges parsed markers/keys with repo-variable evidence lists
+    - accepted JSON shapes include:
+      - object/array entries with `ack_marker`, `ack_key`, optional `acknowledged_at_utc`
+      - object fields `ack_markers`, `ack_keys`, `acknowledgements`
+  - ACK evidence ingestion emits deterministic artifacts:
+    - `ack-evidence-YYYY-MM-DD.json`
+    - `ack-evidence-YYYY-MM-DD.md`
+    - summary includes active markers/keys, stale evidence count, and parse-error count
   - window format (`ET`):
     - `always`
     - or semicolon-delimited entries in `daySpec@HH:MM-HH:MM`
@@ -316,6 +327,8 @@ Runtime notes:
     - `ack_policy` (`deterministic_v1`)
   - dispatcher persists ACK state to `ALERT_ACK_STATE_PATH` and reconciles acknowledged incidents via marker/key evidence on subsequent runs
   - unresolved ACK incidents that breach SLA emit reminder metadata (`ack_reminders_due_count`) and can fan out to reminder/escalation routes
+  - stale ACK state is surfaced in metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`) and excluded from reminder routing
+  - ACK evidence ingestion summary is surfaced in metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -284,6 +284,14 @@ Include:
     - `HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS` (default `2`)
     - `HYBRID_ALERT_ACK_EVIDENCE_MARKERS` (comma/newline/JSON-array list of acknowledged markers)
     - `HYBRID_ALERT_ACK_EVIDENCE_KEYS` (comma/newline/JSON-array list of acknowledged incident keys)
+    - `HYBRID_ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES` (default `10080`; drops stale evidence entries during ingestion)
+    - `HYBRID_ALERT_ACK_STALE_AFTER_MINUTES` (default `1440`; marks pending incidents stale when not seen recently)
+  - optional ACK evidence ingestion directory:
+    - on failure, workflow ingests `artifacts/ack-evidence/*.json` and merges results with repo-variable ACK evidence lists
+    - accepted JSON supports `ack_marker`, `ack_key`, optional `acknowledged_at_utc`, plus aggregate `ack_markers` / `ack_keys` / `acknowledgements` fields
+  - ACK evidence ingestion artifacts emitted on failure:
+    - `ack-evidence-YYYY-MM-DD.json`
+    - `ack-evidence-YYYY-MM-DD.md`
   - escalation window format (`ET`):
     - `always`
     - or semicolon-delimited entries in `daySpec@HH:MM-HH:MM`
@@ -304,7 +312,10 @@ Include:
       - canary-vs-live drift artifact paths (json + markdown)
       - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
+      - ACK stale-expiry metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`)
+      - ACK evidence-ingestion metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
   - dispatcher persists ACK tracker state to `ALERT_ACK_STATE_PATH` and reconciles prior unresolved incidents when evidence vars are provided
+  - stale pending ACK incidents are auto-marked `stale` after the configured expiry window and excluded from reminder fan-out
   - if no webhook routes are configured, workflow logs and skips outbound notification
 
 ## 16) Hybrid retrieval query (entities + chunks)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "db:hybrid:query": "node scripts/db/query-hybrid.mjs",
     "db:hybrid:health": "node scripts/db/hybrid-ingestion-health.mjs",
     "db:hybrid:drift": "node scripts/ci/compare-canary-live-health.mjs",
+    "ci:ack:evidence": "node scripts/ci/ingest-ack-evidence.mjs",
     "md:audit": "node scripts/maintenance/markdown-audit.mjs",
     "md:audit:strict": "node scripts/maintenance/markdown-audit.mjs --strict"
   },

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -236,6 +236,20 @@ function parseAckEvidenceTokens(value) {
   ]).filter(Boolean);
 }
 
+function parseAckEvidenceSummary(pathLike) {
+  const filePath = String(pathLike || "").trim();
+  if (!filePath) return null;
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(resolved, "utf8"));
+    if (typeof parsed !== "object" || parsed == null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 function readAckState(filePath) {
   if (!filePath) return { schema_version: 1, incidents: {} };
   if (!fs.existsSync(filePath)) {
@@ -309,6 +323,8 @@ function buildAlertText({
   ackMarker,
   reminderSummary,
   ackStatePath,
+  staleSummary,
+  ackEvidenceSummary,
 }) {
   const mode = process.env.RUN_MODE || "unknown";
   const repo = process.env.REPO || "unknown";
@@ -396,8 +412,21 @@ function buildAlertText({
       );
     }
   }
+  if (staleSummary.stale_pending_count > 0) {
+    lines.push(
+      `ACK stale expiry: stalePending=${staleSummary.stale_pending_count}, staleAfter=${staleSummary.stale_after_minutes}m, newlyStale=${staleSummary.newly_stale_count}`
+    );
+  }
+  if (ackEvidenceSummary) {
+    lines.push(
+      `ACK evidence ingest: activeMarkers=${ackEvidenceSummary.active_marker_count || 0}, activeKeys=${ackEvidenceSummary.active_key_count || 0}, staleEntries=${ackEvidenceSummary.stale_entry_count || 0}, parseErrors=${ackEvidenceSummary.parse_error_count || 0}`
+    );
+  }
   if (ackStatePath) {
     lines.push(`ACK state file: ${ackStatePath}`);
+  }
+  if (process.env.ALERT_ACK_EVIDENCE_JSON) {
+    lines.push(`ACK evidence artifact: ${process.env.ALERT_ACK_EVIDENCE_JSON}`);
   }
   return lines.join("\n");
 }
@@ -436,8 +465,10 @@ async function main() {
   const ackState = readAckState(ackStatePath);
   const ackReminderIntervalMinutes = toPositiveIntegerOrNull(process.env.ALERT_ACK_REMINDER_INTERVAL_MINUTES) ?? 30;
   const ackEscalateAfterReminders = toPositiveIntegerOrNull(process.env.ALERT_ACK_ESCALATE_AFTER_REMINDERS) ?? 2;
+  const ackStaleAfterMinutes = toPositiveIntegerOrNull(process.env.ALERT_ACK_STALE_AFTER_MINUTES) ?? 1440;
   const ackEvidenceMarkers = new Set(parseAckEvidenceTokens(process.env.ALERT_ACK_EVIDENCE_MARKERS));
   const ackEvidenceKeys = new Set(parseAckEvidenceTokens(process.env.ALERT_ACK_EVIDENCE_KEYS));
+  const ackEvidenceSummary = parseAckEvidenceSummary(process.env.ALERT_ACK_EVIDENCE_JSON);
   const nowIso = new Date().toISOString();
 
   const existing = ackState.incidents[ackKey];
@@ -477,6 +508,20 @@ async function main() {
 
   ackState.incidents[ackKey] = nextIncident;
 
+  let newlyStaleCount = 0;
+  for (const [key, item] of Object.entries(ackState.incidents)) {
+    if (key === ackKey) continue;
+    if (item?.status !== "pending") continue;
+    const lastSeenMinutes = minutesSince(item.last_seen_at_utc || item.first_seen_at_utc);
+    if (lastSeenMinutes == null || lastSeenMinutes < ackStaleAfterMinutes) continue;
+
+    item.status = "stale";
+    item.stale_at_utc = nowIso;
+    item.stale_reason = `last_seen_expired_${ackStaleAfterMinutes}m`;
+    item.next_reminder_at_utc = null;
+    newlyStaleCount += 1;
+  }
+
   const reminderSummary = [];
   for (const [key, item] of Object.entries(ackState.incidents)) {
     if (item?.status !== "pending") continue;
@@ -503,6 +548,13 @@ async function main() {
   }
 
   writeAckState(ackStatePath, ackState);
+
+  const stalePendingCount = Object.values(ackState.incidents).filter((item) => item?.status === "stale").length;
+  const staleSummary = {
+    stale_after_minutes: ackStaleAfterMinutes,
+    stale_pending_count: stalePendingCount,
+    newly_stale_count: newlyStaleCount,
+  };
 
   const escalationWindows = parseEscalationWindows(process.env.ALERT_ESCALATION_WINDOWS_ET);
   const escalationEnabled = escalationRoutes.length > 0 && escalationWindows.some((window) => isWindowMatch(window, nowEt));
@@ -537,6 +589,8 @@ async function main() {
       ackMarker,
       reminderSummary,
       ackStatePath,
+      staleSummary,
+      ackEvidenceSummary,
     }),
     metadata: {
       incident_type: incident.type,
@@ -550,6 +604,14 @@ async function main() {
       ack_reconciliation_source: nextIncident.acknowledgment_source || null,
       ack_reminders_due_count: reminderSummary.length,
       ack_reminder_escalations_due_count: reminderSummary.filter((item) => item.reminder_escalation_due).length,
+      ack_stale_after_minutes: staleSummary.stale_after_minutes,
+      ack_stale_pending_count: staleSummary.stale_pending_count,
+      ack_newly_stale_count: staleSummary.newly_stale_count,
+      ack_evidence_active_marker_count: Number(ackEvidenceSummary?.active_marker_count || 0),
+      ack_evidence_active_key_count: Number(ackEvidenceSummary?.active_key_count || 0),
+      ack_evidence_stale_entry_count: Number(ackEvidenceSummary?.stale_entry_count || 0),
+      ack_evidence_parse_error_count: Number(ackEvidenceSummary?.parse_error_count || 0),
+      ack_evidence_json: process.env.ALERT_ACK_EVIDENCE_JSON || null,
     },
   };
   const dryRun = toBoolean(process.env.ALERT_DRY_RUN);
@@ -575,9 +637,17 @@ async function main() {
     ack_reconciliation_source: nextIncident.acknowledgment_source || null,
     ack_reminders_due_count: reminderSummary.length,
     ack_reminder_escalations_due_count: reminderSummary.filter((item) => item.reminder_escalation_due).length,
+    ack_stale_after_minutes: staleSummary.stale_after_minutes,
+    ack_stale_pending_count: staleSummary.stale_pending_count,
+    ack_newly_stale_count: staleSummary.newly_stale_count,
     ack_sla_minutes: ackMarker.ack_sla_minutes,
     ack_due_at_utc: ackMarker.ack_due_at_utc,
     ack_marker: ackMarker.ack_marker,
+    ack_evidence_active_marker_count: Number(ackEvidenceSummary?.active_marker_count || 0),
+    ack_evidence_active_key_count: Number(ackEvidenceSummary?.active_key_count || 0),
+    ack_evidence_stale_entry_count: Number(ackEvidenceSummary?.stale_entry_count || 0),
+    ack_evidence_parse_error_count: Number(ackEvidenceSummary?.parse_error_count || 0),
+    ack_evidence_json: process.env.ALERT_ACK_EVIDENCE_JSON || null,
     dry_run: dryRun,
   };
   console.log(JSON.stringify(summary, null, 2));

--- a/scripts/ci/ingest-ack-evidence.mjs
+++ b/scripts/ci/ingest-ack-evidence.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    outDir: "artifacts",
+    runDate: "",
+    evidenceDir: "",
+    staleAfterMinutes: null,
+  };
+
+  for (let idx = 0; idx < argv.length; idx += 1) {
+    const token = argv[idx];
+    if (token === "--out-dir") {
+      args.outDir = String(argv[idx + 1] || "").trim() || "artifacts";
+      idx += 1;
+      continue;
+    }
+    if (token === "--run-date") {
+      args.runDate = String(argv[idx + 1] || "").trim();
+      idx += 1;
+      continue;
+    }
+    if (token === "--evidence-dir") {
+      args.evidenceDir = String(argv[idx + 1] || "").trim();
+      idx += 1;
+      continue;
+    }
+    if (token === "--stale-after-minutes") {
+      args.staleAfterMinutes = toPositiveIntegerOrNull(argv[idx + 1]);
+      idx += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return args;
+}
+
+function toPositiveIntegerOrNull(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed <= 0) return null;
+  return Math.floor(parsed);
+}
+
+function toIsoOrNull(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeDateToken(value) {
+  const token = String(value || "").trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(token)) return token;
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(/[\n,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseJsonList(value) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed.map((item) => String(item).trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function unique(items) {
+  return [...new Set(items)];
+}
+
+function parseTokens(value) {
+  return unique([...parseList(value), ...parseJsonList(value)]).filter(Boolean);
+}
+
+function normalizeEvidenceItem(raw, sourcePath) {
+  if (typeof raw === "string") {
+    const token = raw.trim();
+    if (!token) return null;
+    if (token.startsWith("ack-")) {
+      return { ack_marker: token, ack_key: "", acknowledged_at_utc: null, source: sourcePath };
+    }
+    return { ack_marker: "", ack_key: token, acknowledged_at_utc: null, source: sourcePath };
+  }
+
+  if (typeof raw !== "object" || raw == null) return null;
+  const ackMarker = String(raw.ack_marker || raw.marker || "").trim();
+  const ackKey = String(raw.ack_key || raw.key || "").trim();
+  if (!ackMarker && !ackKey) return null;
+
+  return {
+    ack_marker: ackMarker,
+    ack_key: ackKey,
+    acknowledged_at_utc: toIsoOrNull(raw.acknowledged_at_utc || raw.ack_at || raw.ts),
+    source: String(raw.source || sourcePath || "").trim() || sourcePath,
+  };
+}
+
+function collectEvidenceFromJson(payload, sourcePath) {
+  const items = [];
+
+  if (Array.isArray(payload)) {
+    for (const raw of payload) {
+      const item = normalizeEvidenceItem(raw, sourcePath);
+      if (item) items.push(item);
+    }
+    return items;
+  }
+
+  if (typeof payload !== "object" || payload == null) return items;
+
+  const direct = normalizeEvidenceItem(payload, sourcePath);
+  if (direct) items.push(direct);
+
+  for (const marker of Array.isArray(payload.ack_markers) ? payload.ack_markers : []) {
+    const item = normalizeEvidenceItem({ ack_marker: marker }, sourcePath);
+    if (item) items.push(item);
+  }
+  for (const key of Array.isArray(payload.ack_keys) ? payload.ack_keys : []) {
+    const item = normalizeEvidenceItem({ ack_key: key }, sourcePath);
+    if (item) items.push(item);
+  }
+  for (const raw of Array.isArray(payload.acknowledgements) ? payload.acknowledgements : []) {
+    const item = normalizeEvidenceItem(raw, sourcePath);
+    if (item) items.push(item);
+  }
+
+  return items;
+}
+
+function readEvidenceFiles(evidenceDir) {
+  if (!evidenceDir) return [];
+  const resolvedDir = path.resolve(evidenceDir);
+  if (!fs.existsSync(resolvedDir)) return [];
+  if (!fs.statSync(resolvedDir).isDirectory()) return [];
+
+  const files = fs
+    .readdirSync(resolvedDir)
+    .filter((name) => name.toLowerCase().endsWith(".json"))
+    .sort((a, b) => a.localeCompare(b));
+
+  const items = [];
+  for (const file of files) {
+    const fullPath = path.join(resolvedDir, file);
+    try {
+      const parsed = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+      items.push(...collectEvidenceFromJson(parsed, path.relative(process.cwd(), fullPath)));
+    } catch (error) {
+      items.push({
+        ack_marker: "",
+        ack_key: "",
+        acknowledged_at_utc: null,
+        source: path.relative(process.cwd(), fullPath),
+        parse_error: String(error?.message || error),
+      });
+    }
+  }
+  return items;
+}
+
+function minutesSince(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return null;
+  return Math.floor((Date.now() - date.getTime()) / (60 * 1000));
+}
+
+function appendGitHubOutput(kvPairs) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  const lines = [];
+  for (const [key, value] of Object.entries(kvPairs)) {
+    const normalized = String(value ?? "");
+    if (normalized.includes("\n")) {
+      lines.push(`${key}<<EOF`);
+      lines.push(normalized);
+      lines.push("EOF");
+    } else {
+      lines.push(`${key}=${normalized}`);
+    }
+  }
+  fs.appendFileSync(outputFile, `${lines.join("\n")}\n`, "utf8");
+}
+
+function toMarkdown(summary) {
+  const lines = [
+    "# ACK Evidence Ingestion Summary",
+    "",
+    `- Generated (UTC): \`${summary.generated_at_utc}\``,
+    `- Run date: \`${summary.run_date}\``,
+    `- Evidence dir: \`${summary.evidence_dir || "n/a"}\``,
+    `- Stale after minutes: \`${summary.stale_after_minutes}\``,
+    `- Active markers: \`${summary.active_marker_count}\``,
+    `- Active keys: \`${summary.active_key_count}\``,
+    `- Stale evidence entries: \`${summary.stale_entry_count}\``,
+    `- Parse errors: \`${summary.parse_error_count}\``,
+  ];
+
+  if (summary.stale_entry_samples.length > 0) {
+    lines.push("", "## Stale Entry Samples");
+    for (const entry of summary.stale_entry_samples) {
+      lines.push(`- source=\`${entry.source}\`, marker=\`${entry.ack_marker || "n/a"}\`, key=\`${entry.ack_key || "n/a"}\`, acknowledged_at_utc=\`${entry.acknowledged_at_utc || "n/a"}\``);
+    }
+  }
+
+  if (summary.parse_error_samples.length > 0) {
+    lines.push("", "## Parse Error Samples");
+    for (const entry of summary.parse_error_samples) {
+      lines.push(`- source=\`${entry.source}\`, error=\`${entry.parse_error}\``);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const runDate = normalizeDateToken(args.runDate || process.env.RUN_DATE);
+  const outDir = path.resolve(args.outDir);
+  const evidenceDir = args.evidenceDir || process.env.ALERT_ACK_EVIDENCE_DIR || "";
+  const staleAfterMinutes =
+    args.staleAfterMinutes ?? toPositiveIntegerOrNull(process.env.ALERT_ACK_EVIDENCE_STALE_AFTER_MINUTES) ?? 10080;
+
+  const envMarkerTokens = parseTokens(process.env.ALERT_ACK_EVIDENCE_MARKERS).map((marker) => ({
+    ack_marker: marker,
+    ack_key: "",
+    acknowledged_at_utc: null,
+    source: "env:ALERT_ACK_EVIDENCE_MARKERS",
+  }));
+  const envKeyTokens = parseTokens(process.env.ALERT_ACK_EVIDENCE_KEYS).map((key) => ({
+    ack_marker: "",
+    ack_key: key,
+    acknowledged_at_utc: null,
+    source: "env:ALERT_ACK_EVIDENCE_KEYS",
+  }));
+
+  const fileEvidence = readEvidenceFiles(evidenceDir);
+  const rawEntries = [...envMarkerTokens, ...envKeyTokens, ...fileEvidence];
+
+  const activeEntries = [];
+  const staleEntries = [];
+  const parseErrors = [];
+
+  for (const entry of rawEntries) {
+    if (entry.parse_error) {
+      parseErrors.push(entry);
+      continue;
+    }
+
+    if (!entry.ack_marker && !entry.ack_key) continue;
+
+    const ageMinutes = minutesSince(entry.acknowledged_at_utc);
+    const staleByAge = ageMinutes != null && ageMinutes > staleAfterMinutes;
+    if (staleByAge) {
+      staleEntries.push(entry);
+      continue;
+    }
+
+    activeEntries.push(entry);
+  }
+
+  const activeMarkers = unique(activeEntries.map((entry) => entry.ack_marker).filter(Boolean));
+  const activeKeys = unique(activeEntries.map((entry) => entry.ack_key).filter(Boolean));
+
+  const summary = {
+    schema_version: 1,
+    generated_at_utc: new Date().toISOString(),
+    run_date: runDate,
+    evidence_dir: evidenceDir ? path.relative(process.cwd(), path.resolve(evidenceDir)) : "",
+    stale_after_minutes: staleAfterMinutes,
+    raw_entry_count: rawEntries.length,
+    active_entry_count: activeEntries.length,
+    stale_entry_count: staleEntries.length,
+    parse_error_count: parseErrors.length,
+    active_marker_count: activeMarkers.length,
+    active_key_count: activeKeys.length,
+    active_markers: activeMarkers,
+    active_keys: activeKeys,
+    stale_entry_samples: staleEntries.slice(0, 10),
+    parse_error_samples: parseErrors.slice(0, 10),
+  };
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const stem = `ack-evidence-${runDate}`;
+  const jsonPath = path.join(outDir, `${stem}.json`);
+  const mdPath = path.join(outDir, `${stem}.md`);
+  fs.writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  fs.writeFileSync(mdPath, toMarkdown(summary), "utf8");
+
+  appendGitHubOutput({
+    ack_evidence_markers: activeMarkers.join(","),
+    ack_evidence_keys: activeKeys.join(","),
+    ack_evidence_json_path: path.relative(process.cwd(), jsonPath),
+    ack_evidence_md_path: path.relative(process.cwd(), mdPath),
+    ack_evidence_active_marker_count: String(activeMarkers.length),
+    ack_evidence_active_key_count: String(activeKeys.length),
+    ack_evidence_stale_entry_count: String(staleEntries.length),
+    ack_evidence_parse_error_count: String(parseErrors.length),
+    ack_evidence_stale_after_minutes: String(staleAfterMinutes),
+  });
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/ci/ingest-ack-evidence.mjs` to automate ACK evidence ingestion from repo vars + `artifacts/ack-evidence/*.json`
- emit deterministic ingestion artifacts (`ack-evidence-YYYY-MM-DD.{json,md}`) and export parsed active markers/keys for alert dispatch
- wire both canary/live failure alert lanes to run evidence ingestion before `dispatch-hybrid-alert`
- add stale ACK expiry in dispatcher (`ALERT_ACK_STALE_AFTER_MINUTES`) so old pending incidents are marked `stale` and excluded from reminder routing
- surface stale/evidence telemetry in alert `text` and `metadata`
- update runbook docs (`db/README.md`, `docs/RUNBOOK_DEPLOY_GENERIC.md`) and add npm script `ci:ack:evidence`

## Validation
- `node scripts/ci/ingest-ack-evidence.mjs --run-date 2026-04-19 --out-dir artifacts --evidence-dir artifacts/ack-evidence --stale-after-minutes 10080`
- `ALERT_DRY_RUN=1 ... ALERT_ACK_EVIDENCE_MARKERS='["ack-b689fd56e4678a53"]' ALERT_ACK_STALE_AFTER_MINUTES=1 ALERT_ACK_EVIDENCE_JSON=artifacts/ack-evidence-2026-04-19.json node scripts/ci/dispatch-hybrid-alert.mjs`
- stale-expiry simulation with seeded pending state file (`artifacts/test-ack-state-stale.json`) confirmed transition to `status=stale`
- workflow YAML parse check via Ruby `YAML.load_file`
- `npm run md:audit:strict`

Closes #103