### PR TITLE
feat(ci): quality-drift incident routing + ACK escalation policy wiring

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -55,6 +55,14 @@ on:
         description: "Optional weighted drift gate in live mode: fail when drift severity score exceeds this threshold"
         required: false
         default: ""
+      max_quality_drift_signals:
+        description: "Optional quality-drift gate: fail when meeting-prep quality drift signal count exceeds this threshold"
+        required: false
+        default: ""
+      max_quality_severity_score:
+        description: "Optional quality-drift gate: fail when meeting-prep quality severity score exceeds this threshold"
+        required: false
+        default: ""
   schedule:
     - cron: "20 13 * * *"
 
@@ -83,6 +91,8 @@ jobs:
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
       MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
+      MAX_QUALITY_DRIFT_SIGNALS_INPUT: ${{ inputs.max_quality_drift_signals || '' }}
+      MAX_QUALITY_SEVERITY_SCORE_INPUT: ${{ inputs.max_quality_severity_score || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,21 +161,88 @@ jobs:
             --artifact-dir artifacts \
             > "artifacts/ingestion-health-${run_date}.md"
 
-          npm run db:hybrid:health -- \
-            --json \
-            --artifact-dir artifacts \
-            --trend-artifact-dir artifacts \
-            --trend-artifact-prefix ingestion-trends \
-            --trend-retention-count 180 \
-            --slo-digest-dir artifacts \
-            --slo-digest-prefix ingestion-slo-weekly \
-            --slo-window-days 7 \
-            --slo-retention-count 52 \
-            --max-lag-hours "${MAX_LAG_HOURS_INPUT}" \
-            --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}" \
-            --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \
-            --max-slo-budget-burn-pct 100 \
-            | tee "artifacts/ingestion-health-${run_date}.json"
+          cmd=(
+            npm run db:hybrid:health --
+            --json
+            --artifact-dir artifacts
+            --trend-artifact-dir artifacts
+            --trend-artifact-prefix ingestion-trends
+            --trend-retention-count 180
+            --slo-digest-dir artifacts
+            --slo-digest-prefix ingestion-slo-weekly
+            --slo-window-days 7
+            --slo-retention-count 52
+            --max-lag-hours "${MAX_LAG_HOURS_INPUT}"
+            --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}"
+            --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}"
+            --max-slo-budget-burn-pct 100
+          )
+
+          if [[ -n "${MAX_QUALITY_DRIFT_SIGNALS_INPUT:-}" ]]; then
+            cmd+=(--max-quality-drift-signals "${MAX_QUALITY_DRIFT_SIGNALS_INPUT}")
+          fi
+          if [[ -n "${MAX_QUALITY_SEVERITY_SCORE_INPUT:-}" ]]; then
+            cmd+=(--max-quality-severity-score "${MAX_QUALITY_SEVERITY_SCORE_INPUT}")
+          fi
+
+          "${cmd[@]}" | tee "artifacts/ingestion-health-${run_date}.json"
+
+      - name: Extract quality drift metadata
+        if: ${{ always() }}
+        id: quality
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_date="${{ steps.args.outputs.run_date }}"
+          health_json="artifacts/ingestion-health-${run_date}.json"
+
+          HEALTH_JSON="$health_json" node -e '
+            const fs = require("node:fs");
+            const out = process.env.GITHUB_OUTPUT;
+            const fp = process.env.HEALTH_JSON;
+            const fallback = {
+              quality_signal_count: "0",
+              quality_severity_score: "0",
+              quality_top_lane: "",
+              quality_top_lane_severity: "",
+              quality_gate_breached: "false",
+            };
+
+            const append = (kv) => {
+              const lines = [];
+              for (const [k, v] of Object.entries(kv)) lines.push(`${k}=${String(v ?? "")}`);
+              fs.appendFileSync(out, `${lines.join("\n")}\n`, "utf8");
+            };
+
+            if (!fp || !fs.existsSync(fp)) {
+              append(fallback);
+              process.exit(0);
+            }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(fs.readFileSync(fp, "utf8"));
+            } catch {
+              append(fallback);
+              process.exit(0);
+            }
+
+            const prep = parsed && typeof parsed === "object" ? parsed.meeting_prep_quality || {} : {};
+            const driftSignals = Array.isArray(prep.drift_signals) ? prep.drift_signals.length : 0;
+            const severityScore = Number(prep?.latest?.severity_score);
+            const lanes = Array.isArray(prep.escalation_lanes) ? prep.escalation_lanes : [];
+            const lane = lanes[0] || {};
+            const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
+            const qualityGateBreached = breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+
+            append({
+              quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
+              quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
+              quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
+              quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
+              quality_gate_breached: qualityGateBreached ? "true" : "false",
+            });
+          '
 
       - name: Upload artifacts
         if: always()
@@ -206,6 +283,10 @@ jobs:
           ALERT_DRIFT_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_DRIFT_WEBHOOK_URLS }}
           ALERT_DRIFT_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URL }}
           ALERT_DRIFT_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URLS }}
+          ALERT_QUALITY_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_QUALITY_WEBHOOK_URL }}
+          ALERT_QUALITY_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_QUALITY_WEBHOOK_URLS }}
+          ALERT_QUALITY_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URL }}
+          ALERT_QUALITY_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URLS }}
           ALERT_ACK_REMINDER_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL }}
           ALERT_ACK_REMINDER_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS }}
           ALERT_ACK_REMINDER_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_ESCALATION_WEBHOOK_URL }}
@@ -214,6 +295,7 @@ jobs:
           ALERT_ACK_SLA_MINUTES: ${{ vars.HYBRID_ALERT_ACK_SLA_MINUTES || '' }}
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
+          ALERT_ACK_ESCALATION_POLICY_JSON: ${{ vars.HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON || '' }}
           ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
           ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
           ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}
@@ -228,6 +310,11 @@ jobs:
           MAX_LAG_HOURS: ${{ env.MAX_LAG_HOURS_INPUT }}
           MAX_SEEN_DRIFT_HOURS: ${{ env.MAX_SEEN_DRIFT_HOURS_INPUT }}
           MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
+          ALERT_QUALITY_DRIFT_SIGNAL_COUNT: ${{ steps.quality.outputs.quality_signal_count }}
+          ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
+          ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
+          ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
+          ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}
           ALERT_DIGEST_OUT_DIR: artifacts
           ALERT_DIGEST_PREFIX: ack-reminder-digest
           ALERT_SUMMARY_PREFIX: dispatch-alert-summary
@@ -270,6 +357,8 @@ jobs:
       MAX_ARTIFACT_ISSUES_INPUT: ${{ inputs.max_artifact_issues || '0' }}
       MAX_DRIFT_SIGNALS_INPUT: ${{ inputs.max_drift_signals || '' }}
       MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
+      MAX_QUALITY_DRIFT_SIGNALS_INPUT: ${{ inputs.max_quality_drift_signals || '' }}
+      MAX_QUALITY_SEVERITY_SCORE_INPUT: ${{ inputs.max_quality_severity_score || '' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
       LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
       LIVE_APPROVAL_ENVIRONMENT: hybrid-live
@@ -419,21 +508,88 @@ jobs:
             --artifact-dir artifacts \
             > "artifacts/ingestion-health-${run_date}.md"
 
-          npm run db:hybrid:health -- \
-            --json \
-            --artifact-dir artifacts \
-            --trend-artifact-dir artifacts \
-            --trend-artifact-prefix ingestion-trends \
-            --trend-retention-count 180 \
-            --slo-digest-dir artifacts \
-            --slo-digest-prefix ingestion-slo-weekly \
-            --slo-window-days 7 \
-            --slo-retention-count 52 \
-            --max-lag-hours "${MAX_LAG_HOURS_INPUT}" \
-            --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}" \
-            --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}" \
-            --max-slo-budget-burn-pct 100 \
-            | tee "artifacts/ingestion-health-${run_date}.json"
+          cmd=(
+            npm run db:hybrid:health --
+            --json
+            --artifact-dir artifacts
+            --trend-artifact-dir artifacts
+            --trend-artifact-prefix ingestion-trends
+            --trend-retention-count 180
+            --slo-digest-dir artifacts
+            --slo-digest-prefix ingestion-slo-weekly
+            --slo-window-days 7
+            --slo-retention-count 52
+            --max-lag-hours "${MAX_LAG_HOURS_INPUT}"
+            --max-seen-drift-hours "${MAX_SEEN_DRIFT_HOURS_INPUT}"
+            --max-artifact-issues "${MAX_ARTIFACT_ISSUES_INPUT}"
+            --max-slo-budget-burn-pct 100
+          )
+
+          if [[ -n "${MAX_QUALITY_DRIFT_SIGNALS_INPUT:-}" ]]; then
+            cmd+=(--max-quality-drift-signals "${MAX_QUALITY_DRIFT_SIGNALS_INPUT}")
+          fi
+          if [[ -n "${MAX_QUALITY_SEVERITY_SCORE_INPUT:-}" ]]; then
+            cmd+=(--max-quality-severity-score "${MAX_QUALITY_SEVERITY_SCORE_INPUT}")
+          fi
+
+          "${cmd[@]}" | tee "artifacts/ingestion-health-${run_date}.json"
+
+      - name: Extract quality drift metadata
+        if: ${{ always() }}
+        id: quality
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_date="${{ steps.args.outputs.run_date }}"
+          health_json="artifacts/ingestion-health-${run_date}.json"
+
+          HEALTH_JSON="$health_json" node -e '
+            const fs = require("node:fs");
+            const out = process.env.GITHUB_OUTPUT;
+            const fp = process.env.HEALTH_JSON;
+            const fallback = {
+              quality_signal_count: "0",
+              quality_severity_score: "0",
+              quality_top_lane: "",
+              quality_top_lane_severity: "",
+              quality_gate_breached: "false",
+            };
+
+            const append = (kv) => {
+              const lines = [];
+              for (const [k, v] of Object.entries(kv)) lines.push(`${k}=${String(v ?? "")}`);
+              fs.appendFileSync(out, `${lines.join("\n")}\n`, "utf8");
+            };
+
+            if (!fp || !fs.existsSync(fp)) {
+              append(fallback);
+              process.exit(0);
+            }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(fs.readFileSync(fp, "utf8"));
+            } catch {
+              append(fallback);
+              process.exit(0);
+            }
+
+            const prep = parsed && typeof parsed === "object" ? parsed.meeting_prep_quality || {} : {};
+            const driftSignals = Array.isArray(prep.drift_signals) ? prep.drift_signals.length : 0;
+            const severityScore = Number(prep?.latest?.severity_score);
+            const lanes = Array.isArray(prep.escalation_lanes) ? prep.escalation_lanes : [];
+            const lane = lanes[0] || {};
+            const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
+            const qualityGateBreached = breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+
+            append({
+              quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
+              quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
+              quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
+              quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
+              quality_gate_breached: qualityGateBreached ? "true" : "false",
+            });
+          '
 
       - name: Resolve same-date canary artifact baseline
         id: canary
@@ -553,6 +709,10 @@ jobs:
           ALERT_DRIFT_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_DRIFT_WEBHOOK_URLS }}
           ALERT_DRIFT_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URL }}
           ALERT_DRIFT_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URLS }}
+          ALERT_QUALITY_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_QUALITY_WEBHOOK_URL }}
+          ALERT_QUALITY_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_QUALITY_WEBHOOK_URLS }}
+          ALERT_QUALITY_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URL }}
+          ALERT_QUALITY_ESCALATION_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URLS }}
           ALERT_ACK_REMINDER_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL }}
           ALERT_ACK_REMINDER_WEBHOOK_URLS: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS }}
           ALERT_ACK_REMINDER_ESCALATION_WEBHOOK_URL: ${{ secrets.HYBRID_ALERT_ACK_REMINDER_ESCALATION_WEBHOOK_URL }}
@@ -561,6 +721,7 @@ jobs:
           ALERT_ACK_SLA_MINUTES: ${{ vars.HYBRID_ALERT_ACK_SLA_MINUTES || '' }}
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
+          ALERT_ACK_ESCALATION_POLICY_JSON: ${{ vars.HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON || '' }}
           ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
           ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
           ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}
@@ -592,6 +753,11 @@ jobs:
           ALERT_DRIFT_GATE_BREACHED_BY_SEVERITY_SCORE: ${{ steps.drift.outputs.drift_gate_breached_by_severity_score }}
           ALERT_DRIFT_JSON: ${{ steps.drift.outputs.drift_json_path }}
           ALERT_DRIFT_MD: ${{ steps.drift.outputs.drift_md_path }}
+          ALERT_QUALITY_DRIFT_SIGNAL_COUNT: ${{ steps.quality.outputs.quality_signal_count }}
+          ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
+          ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
+          ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
+          ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}
           ALERT_DIGEST_OUT_DIR: artifacts
           ALERT_DIGEST_PREFIX: ack-reminder-digest
           ALERT_SUMMARY_PREFIX: dispatch-alert-summary

--- a/db/README.md
+++ b/db/README.md
@@ -282,15 +282,33 @@ Runtime notes:
   - optional drift-incident route config (used when drift signals exist):
     - `HYBRID_ALERT_DRIFT_WEBHOOK_URL`
     - `HYBRID_ALERT_DRIFT_WEBHOOK_URLS`
+  - optional quality-drift route config (used when meeting-prep quality drift signals exist):
+    - `HYBRID_ALERT_QUALITY_WEBHOOK_URL`
+    - `HYBRID_ALERT_QUALITY_WEBHOOK_URLS`
   - optional escalation route config:
     - `HYBRID_ALERT_ESCALATION_WEBHOOK_URL`
     - `HYBRID_ALERT_ESCALATION_WEBHOOK_URLS`
   - optional drift-escalation route config:
     - `HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URL`
     - `HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URLS`
+  - optional quality-escalation route config:
+    - `HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URL`
+    - `HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URLS`
     - `HYBRID_ALERT_ESCALATION_WINDOWS_ET` (repo variable, defaults to `always`)
   - optional ACK SLA override:
-    - `HYBRID_ALERT_ACK_SLA_MINUTES` (repo variable; defaults are deterministic by incident type/mode)
+    - `HYBRID_ALERT_ACK_SLA_MINUTES` (repo variable; hard override for SLA minutes across all incidents)
+  - optional ACK escalation policy JSON override (repo variable):
+    - `HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON`
+    - schema:
+      - `default`
+      - `run_mode.<canary|live>`
+      - `incident_severity.<medium|high>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+    - each node supports:
+      - `ack_sla_minutes`
+      - `ack_reminder_interval_minutes`
+      - `ack_escalate_after_reminders`
+      - `ack_stale_after_minutes`
   - optional ACK reminder route config:
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL`
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS`
@@ -326,6 +344,7 @@ Runtime notes:
     - examples: `mon-fri@08:00-18:00;sat@09:00-12:00`, `sun@00:00-23:59`
   - on health-gate failure, workflow dispatches one JSON payload (`text` + `metadata`) to all base routes; escalation routes are included only when current ET time is inside configured escalation windows
   - when drift signals are present (`signal_count > 0` or drift gate breached), drift routes are also included; drift escalation routes are ET-window gated like base escalation
+  - when meeting-prep quality drift signals are present (`quality_signal_count > 0` or quality gate breached), quality routes are also included; quality escalation routes are ET-window gated like base escalation
   - live-mode alerts include manual-approval context and emergency control state:
     - approval required flag + environment
     - triggering actor + dispatch actor
@@ -339,16 +358,24 @@ Runtime notes:
     - `ack_sla_minutes`
     - `ack_due_at_utc`
     - `ack_due_at_et`
-    - `ack_policy` (`deterministic_v1`)
+    - `ack_policy` (`deterministic_v2`)
+    - `ack_policy_applied` (ordered policy source list)
+    - `ack_policy_parse_error` (non-empty only when `HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON` is invalid)
+    - quality drift context:
+      - `quality_drift_signal_count`
+      - `quality_severity_score`
+      - `quality_gate_breached`
+      - `quality_top_lane`
+      - `quality_top_lane_severity`
   - dispatcher persists ACK state to `ALERT_ACK_STATE_PATH` and reconciles acknowledged incidents via marker/key evidence on subsequent runs
   - unresolved ACK incidents that breach SLA emit reminder metadata (`ack_reminders_due_count`) and can fan out to reminder/escalation routes
   - stale ACK state is surfaced in metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`) and excluded from reminder routing
   - ACK evidence ingestion summary is surfaced in metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
   - escalation summary contract is emitted in alert metadata under `escalation_summary` with deterministic policy + route fields:
-    - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`
-    - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`
+    - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`, `policy.incident_quality_related`
+    - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`, `routes.quality_configured_count`, `routes.quality_escalation_configured_count`
     - `routes.ack_reminder_configured_count`, `routes.ack_reminder_escalation_configured_count`
-    - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.reminder_escalation_due_count`
+    - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.quality_escalation_enabled`, `routes.reminder_escalation_due_count`
 
 ## Retrieval/query layer (roadmap tranche option #2)
 

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -204,7 +204,7 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`, `max_drift_severity_score`)
+  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`, `max_drift_severity_score`, `max_quality_drift_signals`, `max_quality_severity_score`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
@@ -272,15 +272,33 @@ Include:
   - optional drift-incident route config (used when drift signals exist):
     - `HYBRID_ALERT_DRIFT_WEBHOOK_URL`
     - `HYBRID_ALERT_DRIFT_WEBHOOK_URLS`
+  - optional quality-drift route config (used when meeting-prep quality drift signals exist):
+    - `HYBRID_ALERT_QUALITY_WEBHOOK_URL`
+    - `HYBRID_ALERT_QUALITY_WEBHOOK_URLS`
   - optional escalation route config:
     - `HYBRID_ALERT_ESCALATION_WEBHOOK_URL`
     - `HYBRID_ALERT_ESCALATION_WEBHOOK_URLS`
   - optional drift-escalation route config:
     - `HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URL`
     - `HYBRID_ALERT_DRIFT_ESCALATION_WEBHOOK_URLS`
+  - optional quality-escalation route config:
+    - `HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URL`
+    - `HYBRID_ALERT_QUALITY_ESCALATION_WEBHOOK_URLS`
     - `HYBRID_ALERT_ESCALATION_WINDOWS_ET` (repo variable, defaults to `always`)
   - optional ACK SLA override:
-    - `HYBRID_ALERT_ACK_SLA_MINUTES` (repo variable; defaults are deterministic by incident type/mode)
+    - `HYBRID_ALERT_ACK_SLA_MINUTES` (repo variable; hard override for SLA minutes across all incidents)
+  - optional ACK escalation policy JSON override (repo variable):
+    - `HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON`
+    - schema:
+      - `default`
+      - `run_mode.<canary|live>`
+      - `incident_severity.<medium|high>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+    - each node supports:
+      - `ack_sla_minutes`
+      - `ack_reminder_interval_minutes`
+      - `ack_escalate_after_reminders`
+      - `ack_stale_after_minutes`
   - optional ACK reminder route config:
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL`
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS`
@@ -313,6 +331,7 @@ Include:
     - examples: `mon-fri@08:00-18:00;sat@09:00-12:00`, `sun@00:00-23:59`
   - on health-gate failure, workflow posts a JSON payload (`text` + `metadata`) to all configured base routes and includes escalation routes only when current ET falls inside configured escalation windows
   - when drift signals are present (`signal_count > 0` or drift gate breached), drift routes are also included; drift escalation routes are ET-window gated like base escalation
+  - when meeting-prep quality drift signals are present (`quality_signal_count > 0` or quality gate breached), quality routes are also included; quality escalation routes are ET-window gated like base escalation
   - payload includes:
     - run mode (`canary` or `live`)
     - run URL
@@ -325,15 +344,16 @@ Include:
       - incident-ledger artifact paths (json + markdown)
       - canary-vs-live drift summary (`status`, `signal_count`, `total_severity_score`, `gate_breached`, `gate_breached_by_signal_count`, `gate_breached_by_severity_score`)
       - canary-vs-live drift artifact paths (json + markdown)
-      - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`)
+      - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`, `ack_policy_applied`, `ack_policy_parse_error`)
+      - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
       - ACK stale-expiry metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`)
       - ACK evidence-ingestion metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
       - escalation summary contract (`escalation_summary`) with deterministic policy + route fields:
-        - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`
-        - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`
+        - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`, `policy.incident_quality_related`
+        - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`, `routes.quality_configured_count`, `routes.quality_escalation_configured_count`
         - `routes.ack_reminder_configured_count`, `routes.ack_reminder_escalation_configured_count`
-        - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.reminder_escalation_due_count`
+        - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.quality_escalation_enabled`, `routes.reminder_escalation_due_count`
   - dispatcher persists ACK tracker state to `ALERT_ACK_STATE_PATH` and reconciles prior unresolved incidents when evidence vars are provided
   - stale pending ACK incidents are auto-marked `stale` after the configured expiry window and excluded from reminder fan-out
   - if no webhook routes are configured, workflow logs and skips outbound notification

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -189,22 +189,121 @@ function isWindowMatch(window, nowEt) {
 function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
+  const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualitySignalCount = Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "0");
   if (driftGateBreached) {
-    return { type: "drift_gate_breach", drift_related: true, severity: "high" };
+    return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityGateBreached) {
+    return { type: "quality_drift_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
-    return { type: "drift_signal_detected", drift_related: true, severity: "medium" };
+    return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
   }
-  return { type: "health_gate_breach", drift_related: false, severity: "high" };
+  if (Number.isFinite(qualitySignalCount) && qualitySignalCount > 0) {
+    return { type: "quality_drift_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
+  }
+  return { type: "health_gate_breach", drift_related: false, quality_related: false, severity: "high" };
 }
 
-function resolveAckSlaMinutes({ incident, runMode }) {
-  const explicit = toPositiveIntegerOrNull(process.env.ALERT_ACK_SLA_MINUTES);
-  if (explicit != null) return explicit;
-  if (incident.type === "drift_gate_breach") return 15;
-  if (runMode === "live") return 20;
-  if (incident.type === "drift_signal_detected") return 30;
-  return 45;
+function readAckEscalationPolicy() {
+  const raw = String(process.env.ALERT_ACK_ESCALATION_POLICY_JSON || "").trim();
+  if (!raw) return { config: null, parse_error: null };
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed == null || Array.isArray(parsed)) {
+      return { config: null, parse_error: "ALERT_ACK_ESCALATION_POLICY_JSON must be a JSON object." };
+    }
+    return { config: parsed, parse_error: null };
+  } catch (error) {
+    return { config: null, parse_error: `ALERT_ACK_ESCALATION_POLICY_JSON parse failed: ${error?.message || error}` };
+  }
+}
+
+function normalizeAckPolicyPatch(value) {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return {};
+  const patch = {};
+  const sla = toPositiveIntegerOrNull(value.ack_sla_minutes);
+  const reminderInterval = toPositiveIntegerOrNull(value.ack_reminder_interval_minutes);
+  const escalateAfter = toPositiveIntegerOrNull(value.ack_escalate_after_reminders);
+  const staleAfter = toPositiveIntegerOrNull(value.ack_stale_after_minutes);
+  if (sla != null) patch.ack_sla_minutes = sla;
+  if (reminderInterval != null) patch.ack_reminder_interval_minutes = reminderInterval;
+  if (escalateAfter != null) patch.ack_escalate_after_reminders = escalateAfter;
+  if (staleAfter != null) patch.ack_stale_after_minutes = staleAfter;
+  return patch;
+}
+
+function resolveAckPolicy({ incident, runMode, policyConfig }) {
+  const defaults = {
+    ack_sla_minutes: 45,
+    ack_reminder_interval_minutes: 30,
+    ack_escalate_after_reminders: 2,
+    ack_stale_after_minutes: 1440,
+  };
+
+  if (incident.type === "drift_gate_breach") {
+    defaults.ack_sla_minutes = 15;
+    defaults.ack_reminder_interval_minutes = 15;
+    defaults.ack_escalate_after_reminders = 1;
+  } else if (incident.type === "quality_drift_gate_breach") {
+    defaults.ack_sla_minutes = 20;
+    defaults.ack_reminder_interval_minutes = 20;
+    defaults.ack_escalate_after_reminders = 1;
+  } else if (runMode === "live") {
+    defaults.ack_sla_minutes = 20;
+  } else if (incident.type === "drift_signal_detected") {
+    defaults.ack_sla_minutes = 30;
+  } else if (incident.type === "quality_drift_signal_detected") {
+    defaults.ack_sla_minutes = 35;
+  }
+
+  const applied = ["deterministic_v2_default"];
+  let policy = { ...defaults };
+
+  const applyPatch = (label, candidate) => {
+    const patch = normalizeAckPolicyPatch(candidate);
+    if (!Object.keys(patch).length) return;
+    policy = { ...policy, ...patch };
+    applied.push(label);
+  };
+
+  if (policyConfig) {
+    applyPatch("policy.default", policyConfig.default);
+    applyPatch(`policy.run_mode.${runMode}`, policyConfig.run_mode?.[runMode]);
+    applyPatch(`policy.incident_severity.${incident.severity}`, policyConfig.incident_severity?.[incident.severity]);
+    applyPatch(`policy.incident_type.${incident.type}`, policyConfig.incident_type?.[incident.type]);
+  }
+
+  const explicitSla = toPositiveIntegerOrNull(process.env.ALERT_ACK_SLA_MINUTES);
+  if (explicitSla != null) {
+    policy.ack_sla_minutes = explicitSla;
+    applied.push("env.ALERT_ACK_SLA_MINUTES");
+  }
+
+  const explicitReminderInterval = toPositiveIntegerOrNull(process.env.ALERT_ACK_REMINDER_INTERVAL_MINUTES);
+  if (explicitReminderInterval != null) {
+    policy.ack_reminder_interval_minutes = explicitReminderInterval;
+    applied.push("env.ALERT_ACK_REMINDER_INTERVAL_MINUTES");
+  }
+
+  const explicitEscalateAfter = toPositiveIntegerOrNull(process.env.ALERT_ACK_ESCALATE_AFTER_REMINDERS);
+  if (explicitEscalateAfter != null) {
+    policy.ack_escalate_after_reminders = explicitEscalateAfter;
+    applied.push("env.ALERT_ACK_ESCALATE_AFTER_REMINDERS");
+  }
+
+  const explicitStaleAfter = toPositiveIntegerOrNull(process.env.ALERT_ACK_STALE_AFTER_MINUTES);
+  if (explicitStaleAfter != null) {
+    policy.ack_stale_after_minutes = explicitStaleAfter;
+    applied.push("env.ALERT_ACK_STALE_AFTER_MINUTES");
+  }
+
+  return {
+    ...policy,
+    ack_policy_name: "deterministic_v2",
+    ack_policy_applied: unique(applied),
+  };
 }
 
 function sha1(value) {
@@ -317,17 +416,17 @@ function buildAckKey({ incident, runMode, runDate, repo, branch }) {
   return `${runMode}:${incident.type}:${runDate || "unknown"}:${repo || "unknown"}:${branch || "unknown"}`;
 }
 
-function buildAckMarker({ ackKey, incident, runMode, runDate }) {
+function buildAckMarker({ ackKey, ackPolicy }) {
   const now = new Date();
-  const ackSlaMinutes = resolveAckSlaMinutes({ incident, runMode });
-  const dueAt = new Date(now.getTime() + ackSlaMinutes * 60 * 1000);
+  const dueAt = new Date(now.getTime() + ackPolicy.ack_sla_minutes * 60 * 1000);
   const marker = `ack-${sha1(ackKey).slice(0, 16)}`;
   return {
     ack_key: ackKey,
     ack_required: true,
-    ack_policy: "deterministic_v1",
+    ack_policy: ackPolicy.ack_policy_name,
+    ack_policy_applied: ackPolicy.ack_policy_applied,
     ack_marker: marker,
-    ack_sla_minutes: ackSlaMinutes,
+    ack_sla_minutes: ackPolicy.ack_sla_minutes,
     ack_due_at_utc: dueAt.toISOString(),
     ack_due_at_et: formatEtDateTime(dueAt),
   };
@@ -338,11 +437,14 @@ function buildEscalationSummary({
   nowEt,
   escalationEnabled,
   driftEscalationEnabled,
+  qualityEscalationEnabled,
   escalationWindows,
   baseRoutes,
   escalationRoutes,
   driftRoutes,
   driftEscalationRoutes,
+  qualityRoutes,
+  qualityEscalationRoutes,
   ackReminderRoutes,
   ackReminderEscalationRoutes,
   reminderSummary,
@@ -355,16 +457,20 @@ function buildEscalationSummary({
       et_now: `${nowEt.weekday}@${nowEt.hhmm}`,
       incident_type: incident.type,
       incident_drift_related: incident.drift_related,
+      incident_quality_related: incident.quality_related,
     },
     routes: {
       base_configured_count: baseRoutes.length,
       escalation_configured_count: escalationRoutes.length,
       drift_configured_count: driftRoutes.length,
       drift_escalation_configured_count: driftEscalationRoutes.length,
+      quality_configured_count: qualityRoutes.length,
+      quality_escalation_configured_count: qualityEscalationRoutes.length,
       ack_reminder_configured_count: ackReminderRoutes.length,
       ack_reminder_escalation_configured_count: ackReminderEscalationRoutes.length,
       escalation_enabled: escalationEnabled,
       drift_escalation_enabled: driftEscalationEnabled,
+      quality_escalation_enabled: qualityEscalationEnabled,
       reminder_escalation_due_count: reminderEscalationDueCount,
     },
   };
@@ -398,10 +504,13 @@ function toDigestMarkdown(digest) {
     `- Escalation windows: \`${digest.escalation.policy.windows_et.join(";") || "n/a"}\``,
     `- Escalation enabled: \`${digest.escalation.routes.escalation_enabled}\``,
     `- Drift escalation enabled: \`${digest.escalation.routes.drift_escalation_enabled}\``,
+    `- Quality escalation enabled: \`${digest.escalation.routes.quality_escalation_enabled}\``,
     `- Base routes configured: \`${digest.escalation.routes.base_configured_count}\``,
     `- Escalation routes configured: \`${digest.escalation.routes.escalation_configured_count}\``,
     `- Drift routes configured: \`${digest.escalation.routes.drift_configured_count}\``,
     `- Drift escalation routes configured: \`${digest.escalation.routes.drift_escalation_configured_count}\``,
+    `- Quality routes configured: \`${digest.escalation.routes.quality_configured_count}\``,
+    `- Quality escalation routes configured: \`${digest.escalation.routes.quality_escalation_configured_count}\``,
     `- ACK reminder routes configured: \`${digest.escalation.routes.ack_reminder_configured_count}\``,
     `- ACK reminder escalation routes configured: \`${digest.escalation.routes.ack_reminder_escalation_configured_count}\``,
     `- Reminder escalations due count: \`${digest.escalation.routes.reminder_escalation_due_count}\``,
@@ -422,6 +531,7 @@ function toDigestMarkdown(digest) {
 function buildAlertText({
   escalationEnabled,
   driftEscalationEnabled,
+  qualityEscalationEnabled,
   incident,
   ackMarker,
   reminderSummary,
@@ -456,6 +566,11 @@ function buildAlertText({
   const driftGateBreachedBySeverityScore = process.env.ALERT_DRIFT_GATE_BREACHED_BY_SEVERITY_SCORE || "";
   const driftJson = process.env.ALERT_DRIFT_JSON || "";
   const driftMd = process.env.ALERT_DRIFT_MD || "";
+  const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
+  const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
+  const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityTopLane = process.env.ALERT_QUALITY_TOP_LANE || "";
+  const qualityTopLaneSeverity = process.env.ALERT_QUALITY_TOP_LANE_SEVERITY || "";
 
   const lines = [
     ":rotating_light: Hybrid daily pipeline health gate breached",
@@ -465,13 +580,16 @@ function buildAlertText({
     `Branch: ${branch}`,
     `Run date: ${runDate}`,
     `Thresholds: lag<=${lag}h, drift<=${drift}h, artifactIssues<=${artifactIssues}`,
-    `ACK: key=${ackMarker.ack_key}, marker=${ackMarker.ack_marker}, required=true, sla=${ackMarker.ack_sla_minutes}m, due_utc=${ackMarker.ack_due_at_utc}, due_et=${ackMarker.ack_due_at_et}`,
+    `ACK: key=${ackMarker.ack_key}, marker=${ackMarker.ack_marker}, required=true, policy=${ackMarker.ack_policy}, sla=${ackMarker.ack_sla_minutes}m, due_utc=${ackMarker.ack_due_at_utc}, due_et=${ackMarker.ack_due_at_et}`,
   ];
   if (escalationEnabled) {
     lines.push("Escalation: ACTIVE (inside configured ET window)");
   }
   if (driftEscalationEnabled) {
     lines.push("Drift escalation: ACTIVE (inside configured ET window)");
+  }
+  if (qualityEscalationEnabled) {
+    lines.push("Quality escalation: ACTIVE (inside configured ET window)");
   }
   if (
     approvalRequired === "true" ||
@@ -492,6 +610,18 @@ function buildAlertText({
   lines.push(`Artifacts: ${artifactLabel} (see run page)`);
   if (ledgerJson || ledgerMd) {
     lines.push(`Incident ledger: json=${ledgerJson || "n/a"}, md=${ledgerMd || "n/a"}`);
+  }
+  if (
+    qualitySignals ||
+    qualitySeverityScore ||
+    qualityGateBreached ||
+    qualityTopLane ||
+    qualityTopLaneSeverity ||
+    incident.quality_related
+  ) {
+    lines.push(
+      `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
   }
   if (
     driftStatus ||
@@ -528,7 +658,7 @@ function buildAlertText({
   }
   if (escalationSummary) {
     lines.push(
-      `Escalation summary: baseRoutes=${escalationSummary.routes.base_configured_count}, escalationRoutes=${escalationSummary.routes.escalation_configured_count}, driftRoutes=${escalationSummary.routes.drift_configured_count}, driftEscalationRoutes=${escalationSummary.routes.drift_escalation_configured_count}, reminderEscalationDue=${escalationSummary.routes.reminder_escalation_due_count}`
+      `Escalation summary: baseRoutes=${escalationSummary.routes.base_configured_count}, escalationRoutes=${escalationSummary.routes.escalation_configured_count}, driftRoutes=${escalationSummary.routes.drift_configured_count}, driftEscalationRoutes=${escalationSummary.routes.drift_escalation_configured_count}, qualityRoutes=${escalationSummary.routes.quality_configured_count}, qualityEscalationRoutes=${escalationSummary.routes.quality_escalation_configured_count}, reminderEscalationDue=${escalationSummary.routes.reminder_escalation_due_count}`
     );
   }
   if (ackStatePath) {
@@ -557,6 +687,11 @@ async function main() {
   const escalationRoutes = parseRoutes("ALERT_ESCALATION_WEBHOOK_URL", "ALERT_ESCALATION_WEBHOOK_URLS");
   const driftRoutes = parseRoutes("ALERT_DRIFT_WEBHOOK_URL", "ALERT_DRIFT_WEBHOOK_URLS");
   const driftEscalationRoutes = parseRoutes("ALERT_DRIFT_ESCALATION_WEBHOOK_URL", "ALERT_DRIFT_ESCALATION_WEBHOOK_URLS");
+  const qualityRoutes = parseRoutes("ALERT_QUALITY_WEBHOOK_URL", "ALERT_QUALITY_WEBHOOK_URLS");
+  const qualityEscalationRoutes = parseRoutes(
+    "ALERT_QUALITY_ESCALATION_WEBHOOK_URL",
+    "ALERT_QUALITY_ESCALATION_WEBHOOK_URLS"
+  );
   const ackReminderRoutes = parseRoutes("ALERT_ACK_REMINDER_WEBHOOK_URL", "ALERT_ACK_REMINDER_WEBHOOK_URLS");
   const ackReminderEscalationRoutes = parseRoutes(
     "ALERT_ACK_REMINDER_ESCALATION_WEBHOOK_URL",
@@ -568,17 +703,27 @@ async function main() {
   const runDate = String(process.env.RUN_DATE || "");
   const repo = String(process.env.REPO || "unknown");
   const branch = String(process.env.BRANCH_REF || "unknown");
+  const ackPolicyConfig = readAckEscalationPolicy();
   const ackKey = buildAckKey({ incident, runMode, runDate, repo, branch });
-  const ackMarker = buildAckMarker({ ackKey, incident, runMode, runDate });
+  const ackPolicy = resolveAckPolicy({
+    incident,
+    runMode,
+    policyConfig: ackPolicyConfig.config,
+  });
+  const ackMarker = buildAckMarker({ ackKey, ackPolicy });
   const ackStatePath = String(process.env.ALERT_ACK_STATE_PATH || "").trim();
   const ackState = readAckState(ackStatePath);
-  const ackReminderIntervalMinutes = toPositiveIntegerOrNull(process.env.ALERT_ACK_REMINDER_INTERVAL_MINUTES) ?? 30;
-  const ackEscalateAfterReminders = toPositiveIntegerOrNull(process.env.ALERT_ACK_ESCALATE_AFTER_REMINDERS) ?? 2;
-  const ackStaleAfterMinutes = toPositiveIntegerOrNull(process.env.ALERT_ACK_STALE_AFTER_MINUTES) ?? 1440;
+  const ackReminderIntervalMinutes = ackPolicy.ack_reminder_interval_minutes;
+  const ackEscalateAfterReminders = ackPolicy.ack_escalate_after_reminders;
+  const ackStaleAfterMinutes = ackPolicy.ack_stale_after_minutes;
   const ackEvidenceMarkers = new Set(parseAckEvidenceTokens(process.env.ALERT_ACK_EVIDENCE_MARKERS));
   const ackEvidenceKeys = new Set(parseAckEvidenceTokens(process.env.ALERT_ACK_EVIDENCE_KEYS));
   const ackEvidenceSummary = parseAckEvidenceSummary(process.env.ALERT_ACK_EVIDENCE_JSON);
   const nowIso = new Date().toISOString();
+
+  if (ackPolicyConfig.parse_error) {
+    console.warn(ackPolicyConfig.parse_error);
+  }
 
   const existing = ackState.incidents[ackKey];
   const nextIncident = {
@@ -671,16 +816,23 @@ async function main() {
     incident.drift_related &&
     driftEscalationRoutes.length > 0 &&
     escalationWindows.some((window) => isWindowMatch(window, nowEt));
+  const qualityEscalationEnabled =
+    incident.quality_related &&
+    qualityEscalationRoutes.length > 0 &&
+    escalationWindows.some((window) => isWindowMatch(window, nowEt));
   const escalationSummary = buildEscalationSummary({
     incident,
     nowEt,
     escalationEnabled,
     driftEscalationEnabled,
+    qualityEscalationEnabled,
     escalationWindows,
     baseRoutes,
     escalationRoutes,
     driftRoutes,
     driftEscalationRoutes,
+    qualityRoutes,
+    qualityEscalationRoutes,
     ackReminderRoutes,
     ackReminderEscalationRoutes,
     reminderSummary,
@@ -691,6 +843,8 @@ async function main() {
     ...(escalationEnabled ? escalationRoutes : []),
     ...(incident.drift_related ? driftRoutes : []),
     ...(driftEscalationEnabled ? driftEscalationRoutes : []),
+    ...(incident.quality_related ? qualityRoutes : []),
+    ...(qualityEscalationEnabled ? qualityEscalationRoutes : []),
     ...(reminderSummary.length > 0 ? ackReminderRoutes : []),
     ...(reminderSummary.some((item) => item.reminder_escalation_due)
       ? ackReminderEscalationRoutes.length > 0
@@ -705,6 +859,7 @@ async function main() {
     text: buildAlertText({
       escalationEnabled,
       driftEscalationEnabled,
+      qualityEscalationEnabled,
       incident,
       ackMarker,
       reminderSummary,
@@ -734,6 +889,13 @@ async function main() {
       ack_evidence_stale_entry_count: Number(ackEvidenceSummary?.stale_entry_count || 0),
       ack_evidence_parse_error_count: Number(ackEvidenceSummary?.parse_error_count || 0),
       ack_evidence_json: process.env.ALERT_ACK_EVIDENCE_JSON || null,
+      ack_policy_applied: ackPolicy.ack_policy_applied,
+      ack_policy_parse_error: ackPolicyConfig.parse_error,
+      quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
+      quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
+      quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_top_lane: process.env.ALERT_QUALITY_TOP_LANE || null,
+      quality_top_lane_severity: process.env.ALERT_QUALITY_TOP_LANE_SEVERITY || null,
     },
   };
   const dryRun = toBoolean(process.env.ALERT_DRY_RUN);
@@ -742,14 +904,18 @@ async function main() {
     routes_total: destinationRoutes.length,
     incident_type: incident.type,
     incident_drift_related: incident.drift_related,
+    incident_quality_related: incident.quality_related,
     base_routes: baseRoutes.length,
     escalation_routes: escalationRoutes.length,
     drift_routes: driftRoutes.length,
     drift_escalation_routes: driftEscalationRoutes.length,
+    quality_routes: qualityRoutes.length,
+    quality_escalation_routes: qualityEscalationRoutes.length,
     ack_reminder_routes: ackReminderRoutes.length,
     ack_reminder_escalation_routes: ackReminderEscalationRoutes.length,
     escalation_enabled: escalationEnabled,
     drift_escalation_enabled: driftEscalationEnabled,
+    quality_escalation_enabled: qualityEscalationEnabled,
     escalation_windows: escalationWindows.map((window) => window.source),
     et_now: `${nowEt.weekday}@${nowEt.hhmm}`,
     ack_key: ackMarker.ack_key,
@@ -765,6 +931,9 @@ async function main() {
     ack_sla_minutes: ackMarker.ack_sla_minutes,
     ack_due_at_utc: ackMarker.ack_due_at_utc,
     ack_marker: ackMarker.ack_marker,
+    ack_policy: ackMarker.ack_policy,
+    ack_policy_applied: ackPolicy.ack_policy_applied,
+    ack_policy_parse_error: ackPolicyConfig.parse_error,
     ack_evidence_active_marker_count: Number(ackEvidenceSummary?.active_marker_count || 0),
     ack_evidence_active_key_count: Number(ackEvidenceSummary?.active_key_count || 0),
     ack_evidence_stale_entry_count: Number(ackEvidenceSummary?.stale_entry_count || 0),
@@ -785,6 +954,9 @@ async function main() {
       ack_required: true,
       ack_key: ackMarker.ack_key,
       ack_marker: ackMarker.ack_marker,
+      ack_policy: ackMarker.ack_policy,
+      ack_policy_applied: ackPolicy.ack_policy_applied,
+      ack_policy_parse_error: ackPolicyConfig.parse_error,
       ack_sla_minutes: ackMarker.ack_sla_minutes,
       ack_due_at_utc: ackMarker.ack_due_at_utc,
       ack_due_at_et: ackMarker.ack_due_at_et,


### PR DESCRIPTION
## Summary
Implements live ops phase 9 by wiring meeting-prep quality drift into alert routing and making ACK escalation behavior policy-configurable.

## Changes
- `scripts/ci/dispatch-hybrid-alert.mjs`
  - Added quality-drift incident classification:
    - `quality_drift_signal_detected`
    - `quality_drift_gate_breach`
  - Added quality route families:
    - `ALERT_QUALITY_WEBHOOK_URL(_S)`
    - `ALERT_QUALITY_ESCALATION_WEBHOOK_URL(_S)`
  - Added ACK escalation policy wiring:
    - `ALERT_ACK_ESCALATION_POLICY_JSON` parser + merge logic
    - deterministic defaults upgraded to `deterministic_v2`
    - supports policy scopes: `default`, `run_mode`, `incident_severity`, `incident_type`
  - Enriched alert metadata and escalation summary with quality context and policy fields.

- `.github/workflows/hybrid-daily-pipeline.yml`
  - Added dispatch inputs:
    - `max_quality_drift_signals`
    - `max_quality_severity_score`
  - Added optional quality threshold flags into health-gated JSON run (canary + live).
  - Added `Extract quality drift metadata` step (canary + live) to export:
    - `quality_signal_count`
    - `quality_severity_score`
    - `quality_top_lane`
    - `quality_top_lane_severity`
    - `quality_gate_breached`
  - Wired new quality route env vars + ACK policy JSON var into dispatcher (canary + live).

- Docs updated:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- YAML parse check for `.github/workflows/hybrid-daily-pipeline.yml`
- `npm run md:audit:strict`
- Dispatcher dry-runs:
  - quality-drift gate-breach scenario with policy override
  - drift-signal scenario

Closes #121