### PR TITLE
feat(alerts): incident-age ACK policy tuning + deterministic age controls

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -63,6 +63,14 @@ on:
         description: "Optional quality-drift gate: fail when meeting-prep quality severity score exceeds this threshold"
         required: false
         default: ""
+      incident_age_warning_minutes:
+        description: "Optional alert control: aging threshold in minutes for incident-age policy overlays"
+        required: false
+        default: ""
+      incident_age_critical_minutes:
+        description: "Optional alert control: critical threshold in minutes for incident-age policy overlays"
+        required: false
+        default: ""
   schedule:
     - cron: "20 13 * * *"
 
@@ -93,6 +101,8 @@ jobs:
       MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
       MAX_QUALITY_DRIFT_SIGNALS_INPUT: ${{ inputs.max_quality_drift_signals || '' }}
       MAX_QUALITY_SEVERITY_SCORE_INPUT: ${{ inputs.max_quality_severity_score || '' }}
+      INCIDENT_AGE_WARNING_MINUTES_INPUT: ${{ inputs.incident_age_warning_minutes || '' }}
+      INCIDENT_AGE_CRITICAL_MINUTES_INPUT: ${{ inputs.incident_age_critical_minutes || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -296,6 +306,8 @@ jobs:
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
           ALERT_ACK_ESCALATION_POLICY_JSON: ${{ vars.HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON || '' }}
+          ALERT_INCIDENT_AGE_WARNING_MINUTES: ${{ env.INCIDENT_AGE_WARNING_MINUTES_INPUT || vars.HYBRID_ALERT_INCIDENT_AGE_WARNING_MINUTES || '180' }}
+          ALERT_INCIDENT_AGE_CRITICAL_MINUTES: ${{ env.INCIDENT_AGE_CRITICAL_MINUTES_INPUT || vars.HYBRID_ALERT_INCIDENT_AGE_CRITICAL_MINUTES || '720' }}
           ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
           ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
           ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}
@@ -359,6 +371,8 @@ jobs:
       MAX_DRIFT_SEVERITY_SCORE_INPUT: ${{ inputs.max_drift_severity_score || '' }}
       MAX_QUALITY_DRIFT_SIGNALS_INPUT: ${{ inputs.max_quality_drift_signals || '' }}
       MAX_QUALITY_SEVERITY_SCORE_INPUT: ${{ inputs.max_quality_severity_score || '' }}
+      INCIDENT_AGE_WARNING_MINUTES_INPUT: ${{ inputs.incident_age_warning_minutes || '' }}
+      INCIDENT_AGE_CRITICAL_MINUTES_INPUT: ${{ inputs.incident_age_critical_minutes || '' }}
       LIVE_ALLOWED_ACTORS_INPUT: ${{ vars.HYBRID_LIVE_ALLOWED_ACTORS || 'richducat' }}
       LIVE_EMERGENCY_STOP_INPUT: ${{ vars.HYBRID_LIVE_EMERGENCY_STOP || 'false' }}
       LIVE_APPROVAL_ENVIRONMENT: hybrid-live
@@ -722,6 +736,8 @@ jobs:
           ALERT_ACK_REMINDER_INTERVAL_MINUTES: ${{ vars.HYBRID_ALERT_ACK_REMINDER_INTERVAL_MINUTES || '30' }}
           ALERT_ACK_ESCALATE_AFTER_REMINDERS: ${{ vars.HYBRID_ALERT_ACK_ESCALATE_AFTER_REMINDERS || '2' }}
           ALERT_ACK_ESCALATION_POLICY_JSON: ${{ vars.HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON || '' }}
+          ALERT_INCIDENT_AGE_WARNING_MINUTES: ${{ env.INCIDENT_AGE_WARNING_MINUTES_INPUT || vars.HYBRID_ALERT_INCIDENT_AGE_WARNING_MINUTES || '180' }}
+          ALERT_INCIDENT_AGE_CRITICAL_MINUTES: ${{ env.INCIDENT_AGE_CRITICAL_MINUTES_INPUT || vars.HYBRID_ALERT_INCIDENT_AGE_CRITICAL_MINUTES || '720' }}
           ALERT_ACK_EVIDENCE_MARKERS: ${{ steps.ack_evidence.outputs.ack_evidence_markers }}
           ALERT_ACK_EVIDENCE_KEYS: ${{ steps.ack_evidence.outputs.ack_evidence_keys }}
           ALERT_ACK_EVIDENCE_JSON: ${{ steps.ack_evidence.outputs.ack_evidence_json_path }}

--- a/db/README.md
+++ b/db/README.md
@@ -217,6 +217,8 @@ Triggers:
   - `max_artifact_issues`
   - `max_drift_signals` (optional live drift gate; blank = report-only)
   - `max_drift_severity_score` (optional weighted live drift gate; blank = report-only)
+  - `incident_age_warning_minutes` (optional alert override; blank = repo variable/default)
+  - `incident_age_critical_minutes` (optional alert override; blank = repo variable/default)
 
 Artifacts:
 - `meeting-prep-YYYY-MM-DD.md`
@@ -309,11 +311,15 @@ Runtime notes:
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
       - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+      - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
       - `ack_reminder_interval_minutes`
       - `ack_escalate_after_reminders`
       - `ack_stale_after_minutes`
+  - optional incident-age thresholds (repo variables or workflow dispatch input overrides):
+    - `HYBRID_ALERT_INCIDENT_AGE_WARNING_MINUTES` (default `180`)
+    - `HYBRID_ALERT_INCIDENT_AGE_CRITICAL_MINUTES` (default `720`)
   - optional ACK reminder route config:
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL`
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS`
@@ -366,6 +372,13 @@ Runtime notes:
     - `ack_policy` (`deterministic_v2`)
     - `ack_policy_applied` (ordered policy source list)
     - `ack_policy_parse_error` (non-empty only when `HYBRID_ALERT_ACK_ESCALATION_POLICY_JSON` is invalid)
+    - incident-age controls:
+      - `incident_age_minutes`
+      - `incident_age_band` (`new|fresh|aging|critical`)
+      - `incident_age_warning_minutes`
+      - `incident_age_critical_minutes`
+      - `incident_age_escalation_due`
+      - `incident_first_seen_at_utc`
     - quality drift context:
       - `quality_drift_signal_count`
       - `quality_severity_score`
@@ -378,6 +391,7 @@ Runtime notes:
   - ACK evidence ingestion summary is surfaced in metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
   - escalation summary contract is emitted in alert metadata under `escalation_summary` with deterministic policy + route fields:
     - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`, `policy.incident_quality_related`
+    - `policy.incident_age_band`, `policy.incident_age_minutes`, `policy.incident_age_warning_minutes`, `policy.incident_age_critical_minutes`, `policy.incident_age_escalation_due`
     - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`, `routes.quality_configured_count`, `routes.quality_escalation_configured_count`
     - `routes.ack_reminder_configured_count`, `routes.ack_reminder_escalation_configured_count`
     - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.quality_escalation_enabled`, `routes.reminder_escalation_due_count`

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -206,7 +206,7 @@ Include:
 - Workflow: `.github/workflows/hybrid-daily-pipeline.yml`
 - Runs:
   - daily at `13:20 UTC`
-  - manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`, `max_drift_severity_score`, `max_quality_drift_signals`, `max_quality_severity_score`)
+- manual dispatch with inputs (`account`, `date`, `use_fixtures`, `live_mode`, `break_glass`, `break_glass_reason`, `skip_kb`, `max_lag_hours`, `max_seen_drift_hours`, `max_artifact_issues`, `max_drift_signals`, `max_drift_severity_score`, `max_quality_drift_signals`, `max_quality_severity_score`, `incident_age_warning_minutes`, `incident_age_critical_minutes`)
 - Artifacts kept for 14 days:
   - `meeting-prep-YYYY-MM-DD.md`
   - `pipeline-summary-YYYY-MM-DD.json`
@@ -296,11 +296,15 @@ Include:
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
       - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+      - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
       - `ack_reminder_interval_minutes`
       - `ack_escalate_after_reminders`
       - `ack_stale_after_minutes`
+  - optional incident-age thresholds (repo vars; workflow dispatch inputs can override per run):
+    - `HYBRID_ALERT_INCIDENT_AGE_WARNING_MINUTES` (default `180`)
+    - `HYBRID_ALERT_INCIDENT_AGE_CRITICAL_MINUTES` (default `720`)
   - optional ACK reminder route config:
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URL`
     - `HYBRID_ALERT_ACK_REMINDER_WEBHOOK_URLS`
@@ -347,12 +351,14 @@ Include:
       - canary-vs-live drift summary (`status`, `signal_count`, `total_severity_score`, `gate_breached`, `gate_breached_by_signal_count`, `gate_breached_by_severity_score`)
       - canary-vs-live drift artifact paths (json + markdown)
       - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`, `ack_policy_applied`, `ack_policy_parse_error`)
+      - deterministic incident-age metadata (`incident_age_minutes`, `incident_age_band`, `incident_age_warning_minutes`, `incident_age_critical_minutes`, `incident_age_escalation_due`, `incident_first_seen_at_utc`)
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
       - ACK stale-expiry metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`)
       - ACK evidence-ingestion metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)
       - escalation summary contract (`escalation_summary`) with deterministic policy + route fields:
         - `policy.windows_et`, `policy.et_now`, `policy.incident_type`, `policy.incident_drift_related`, `policy.incident_quality_related`
+        - `policy.incident_age_band`, `policy.incident_age_minutes`, `policy.incident_age_warning_minutes`, `policy.incident_age_critical_minutes`, `policy.incident_age_escalation_due`
         - `routes.base_configured_count`, `routes.escalation_configured_count`, `routes.drift_configured_count`, `routes.drift_escalation_configured_count`, `routes.quality_configured_count`, `routes.quality_escalation_configured_count`
         - `routes.ack_reminder_configured_count`, `routes.ack_reminder_escalation_configured_count`
         - `routes.escalation_enabled`, `routes.drift_escalation_enabled`, `routes.quality_escalation_enabled`, `routes.reminder_escalation_due_count`

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -41,6 +41,13 @@ function toPositiveIntegerOrNull(value) {
   return Math.floor(parsed);
 }
 
+function toNonNegativeIntegerOrNull(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed < 0) return null;
+  return Math.floor(parsed);
+}
+
 function parseRoutes(singleVar, listVar) {
   const single = process.env[singleVar] ? [String(process.env[singleVar]).trim()] : [];
   const list = parseList(process.env[listVar]);
@@ -306,6 +313,71 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
   };
 }
 
+function resolveIncidentAgeProfile(existingIncident) {
+  const warningMinutes = toPositiveIntegerOrNull(process.env.ALERT_INCIDENT_AGE_WARNING_MINUTES) ?? 180;
+  const criticalMinutes = toPositiveIntegerOrNull(process.env.ALERT_INCIDENT_AGE_CRITICAL_MINUTES) ?? 720;
+  const effectiveCriticalMinutes = criticalMinutes > warningMinutes ? criticalMinutes : warningMinutes + 1;
+
+  const firstSeenAtUtc = toIsoOrNull(existingIncident?.first_seen_at_utc);
+  const ageMinutesRaw = toNonNegativeIntegerOrNull(minutesSince(firstSeenAtUtc));
+  const ageMinutes = ageMinutesRaw ?? 0;
+
+  let band = "new";
+  if (firstSeenAtUtc != null) {
+    if (ageMinutes >= effectiveCriticalMinutes) {
+      band = "critical";
+    } else if (ageMinutes >= warningMinutes) {
+      band = "aging";
+    } else {
+      band = "fresh";
+    }
+  }
+
+  return {
+    first_seen_at_utc: firstSeenAtUtc,
+    age_minutes: ageMinutes,
+    band,
+    warning_minutes: warningMinutes,
+    critical_minutes: effectiveCriticalMinutes,
+    escalation_due: firstSeenAtUtc != null && ageMinutes >= warningMinutes,
+  };
+}
+
+function applyIncidentAgePolicy({ policy, applied, ageProfile, incident, policyConfig }) {
+  let nextPolicy = { ...policy };
+  const nextApplied = [...applied];
+
+  const applyPatch = (label, candidate) => {
+    const patch = normalizeAckPolicyPatch(candidate);
+    if (!Object.keys(patch).length) return;
+    nextPolicy = { ...nextPolicy, ...patch };
+    nextApplied.push(label);
+  };
+
+  if (incident.quality_related) {
+    if (ageProfile.band === "aging") {
+      nextPolicy.ack_sla_minutes = Math.min(nextPolicy.ack_sla_minutes, 20);
+      nextPolicy.ack_reminder_interval_minutes = Math.min(nextPolicy.ack_reminder_interval_minutes, 15);
+      nextPolicy.ack_escalate_after_reminders = Math.min(nextPolicy.ack_escalate_after_reminders, 2);
+      nextApplied.push("deterministic_v2_quality_age.aging");
+    } else if (ageProfile.band === "critical") {
+      nextPolicy.ack_sla_minutes = Math.min(nextPolicy.ack_sla_minutes, 10);
+      nextPolicy.ack_reminder_interval_minutes = Math.min(nextPolicy.ack_reminder_interval_minutes, 10);
+      nextPolicy.ack_escalate_after_reminders = Math.min(nextPolicy.ack_escalate_after_reminders, 1);
+      nextApplied.push("deterministic_v2_quality_age.critical");
+    }
+  }
+
+  if (policyConfig) {
+    applyPatch(`policy.incident_age_band.${ageProfile.band}`, policyConfig.incident_age_band?.[ageProfile.band]);
+  }
+
+  return {
+    policy: nextPolicy,
+    applied: unique(nextApplied),
+  };
+}
+
 function sha1(value) {
   return crypto.createHash("sha1").update(value).digest("hex");
 }
@@ -448,6 +520,7 @@ function buildEscalationSummary({
   ackReminderRoutes,
   ackReminderEscalationRoutes,
   reminderSummary,
+  incidentAgeProfile,
 }) {
   const reminderEscalationDueCount = reminderSummary.filter((item) => item.reminder_escalation_due).length;
   return {
@@ -458,6 +531,11 @@ function buildEscalationSummary({
       incident_type: incident.type,
       incident_drift_related: incident.drift_related,
       incident_quality_related: incident.quality_related,
+      incident_age_band: incidentAgeProfile.band,
+      incident_age_minutes: incidentAgeProfile.age_minutes,
+      incident_age_warning_minutes: incidentAgeProfile.warning_minutes,
+      incident_age_critical_minutes: incidentAgeProfile.critical_minutes,
+      incident_age_escalation_due: incidentAgeProfile.escalation_due,
     },
     routes: {
       base_configured_count: baseRoutes.length,
@@ -486,6 +564,7 @@ function toDigestMarkdown(digest) {
     `- Incident type: \`${digest.incident_type}\``,
     `- ACK key: \`${digest.ack.ack_key}\``,
     `- ACK marker: \`${digest.ack.ack_marker}\``,
+    `- Incident age: \`${digest.ack.incident_age_minutes}m (${digest.ack.incident_age_band})\``,
     `- ACK required: \`${digest.ack.ack_required}\``,
     `- ACK reconciled: \`${digest.ack.reconciled}\``,
     `- ACK due (UTC): \`${digest.ack.ack_due_at_utc}\``,
@@ -502,6 +581,7 @@ function toDigestMarkdown(digest) {
     "## Escalation Summary Contract",
     `- ET window now: \`${digest.escalation.policy.et_now}\``,
     `- Escalation windows: \`${digest.escalation.policy.windows_et.join(";") || "n/a"}\``,
+    `- Incident age escalation due: \`${digest.escalation.policy.incident_age_escalation_due}\``,
     `- Escalation enabled: \`${digest.escalation.routes.escalation_enabled}\``,
     `- Drift escalation enabled: \`${digest.escalation.routes.drift_escalation_enabled}\``,
     `- Quality escalation enabled: \`${digest.escalation.routes.quality_escalation_enabled}\``,
@@ -539,6 +619,7 @@ function buildAlertText({
   staleSummary,
   ackEvidenceSummary,
   escalationSummary,
+  incidentAgeProfile,
 }) {
   const mode = process.env.RUN_MODE || "unknown";
   const repo = process.env.REPO || "unknown";
@@ -580,6 +661,7 @@ function buildAlertText({
     `Branch: ${branch}`,
     `Run date: ${runDate}`,
     `Thresholds: lag<=${lag}h, drift<=${drift}h, artifactIssues<=${artifactIssues}`,
+    `Incident age: band=${incidentAgeProfile.band}, age=${incidentAgeProfile.age_minutes}m, warning>=${incidentAgeProfile.warning_minutes}m, critical>=${incidentAgeProfile.critical_minutes}m, escalationDue=${incidentAgeProfile.escalation_due}`,
     `ACK: key=${ackMarker.ack_key}, marker=${ackMarker.ack_marker}, required=true, policy=${ackMarker.ack_policy}, sla=${ackMarker.ack_sla_minutes}m, due_utc=${ackMarker.ack_due_at_utc}, due_et=${ackMarker.ack_due_at_et}`,
   ];
   if (escalationEnabled) {
@@ -703,16 +785,30 @@ async function main() {
   const runDate = String(process.env.RUN_DATE || "");
   const repo = String(process.env.REPO || "unknown");
   const branch = String(process.env.BRANCH_REF || "unknown");
+  const ackStatePath = String(process.env.ALERT_ACK_STATE_PATH || "").trim();
+  const ackState = readAckState(ackStatePath);
   const ackPolicyConfig = readAckEscalationPolicy();
   const ackKey = buildAckKey({ incident, runMode, runDate, repo, branch });
+  const existing = ackState.incidents[ackKey];
+  const incidentAgeProfile = resolveIncidentAgeProfile(existing);
   const ackPolicy = resolveAckPolicy({
     incident,
     runMode,
     policyConfig: ackPolicyConfig.config,
   });
+  const agePolicyOverlay = applyIncidentAgePolicy({
+    policy: ackPolicy,
+    applied: ackPolicy.ack_policy_applied,
+    ageProfile: incidentAgeProfile,
+    incident,
+    policyConfig: ackPolicyConfig.config,
+  });
+  ackPolicy.ack_sla_minutes = agePolicyOverlay.policy.ack_sla_minutes;
+  ackPolicy.ack_reminder_interval_minutes = agePolicyOverlay.policy.ack_reminder_interval_minutes;
+  ackPolicy.ack_escalate_after_reminders = agePolicyOverlay.policy.ack_escalate_after_reminders;
+  ackPolicy.ack_stale_after_minutes = agePolicyOverlay.policy.ack_stale_after_minutes;
+  ackPolicy.ack_policy_applied = agePolicyOverlay.applied;
   const ackMarker = buildAckMarker({ ackKey, ackPolicy });
-  const ackStatePath = String(process.env.ALERT_ACK_STATE_PATH || "").trim();
-  const ackState = readAckState(ackStatePath);
   const ackReminderIntervalMinutes = ackPolicy.ack_reminder_interval_minutes;
   const ackEscalateAfterReminders = ackPolicy.ack_escalate_after_reminders;
   const ackStaleAfterMinutes = ackPolicy.ack_stale_after_minutes;
@@ -725,7 +821,6 @@ async function main() {
     console.warn(ackPolicyConfig.parse_error);
   }
 
-  const existing = ackState.incidents[ackKey];
   const nextIncident = {
     ack_key: ackKey,
     ack_marker: ackMarker.ack_marker,
@@ -744,6 +839,8 @@ async function main() {
     reminder_count: Number(existing?.reminder_count || 0),
     last_reminder_at_utc: toIsoOrNull(existing?.last_reminder_at_utc) || null,
     next_reminder_at_utc: toIsoOrNull(existing?.next_reminder_at_utc) || null,
+    incident_age_minutes: incidentAgeProfile.age_minutes,
+    incident_age_band: incidentAgeProfile.band,
   };
 
   if (ackEvidenceMarkers.has(nextIncident.ack_marker) || ackEvidenceKeys.has(nextIncident.ack_key)) {
@@ -836,6 +933,7 @@ async function main() {
     ackReminderRoutes,
     ackReminderEscalationRoutes,
     reminderSummary,
+    incidentAgeProfile,
   });
 
   const destinationRoutes = unique([
@@ -862,12 +960,13 @@ async function main() {
       qualityEscalationEnabled,
       incident,
       ackMarker,
-      reminderSummary,
-      ackStatePath,
-      staleSummary,
-      ackEvidenceSummary,
-      escalationSummary,
-    }),
+    reminderSummary,
+    ackStatePath,
+    staleSummary,
+    ackEvidenceSummary,
+    escalationSummary,
+    incidentAgeProfile,
+  }),
     metadata: {
       incident_type: incident.type,
       incident_severity: incident.severity,
@@ -891,6 +990,12 @@ async function main() {
       ack_evidence_json: process.env.ALERT_ACK_EVIDENCE_JSON || null,
       ack_policy_applied: ackPolicy.ack_policy_applied,
       ack_policy_parse_error: ackPolicyConfig.parse_error,
+      incident_age_minutes: incidentAgeProfile.age_minutes,
+      incident_age_band: incidentAgeProfile.band,
+      incident_age_warning_minutes: incidentAgeProfile.warning_minutes,
+      incident_age_critical_minutes: incidentAgeProfile.critical_minutes,
+      incident_age_escalation_due: incidentAgeProfile.escalation_due,
+      incident_first_seen_at_utc: incidentAgeProfile.first_seen_at_utc,
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
@@ -934,6 +1039,12 @@ async function main() {
     ack_policy: ackMarker.ack_policy,
     ack_policy_applied: ackPolicy.ack_policy_applied,
     ack_policy_parse_error: ackPolicyConfig.parse_error,
+    incident_age_minutes: incidentAgeProfile.age_minutes,
+    incident_age_band: incidentAgeProfile.band,
+    incident_age_warning_minutes: incidentAgeProfile.warning_minutes,
+    incident_age_critical_minutes: incidentAgeProfile.critical_minutes,
+    incident_age_escalation_due: incidentAgeProfile.escalation_due,
+    incident_first_seen_at_utc: incidentAgeProfile.first_seen_at_utc,
     ack_evidence_active_marker_count: Number(ackEvidenceSummary?.active_marker_count || 0),
     ack_evidence_active_key_count: Number(ackEvidenceSummary?.active_key_count || 0),
     ack_evidence_stale_entry_count: Number(ackEvidenceSummary?.stale_entry_count || 0),
@@ -957,6 +1068,12 @@ async function main() {
       ack_policy: ackMarker.ack_policy,
       ack_policy_applied: ackPolicy.ack_policy_applied,
       ack_policy_parse_error: ackPolicyConfig.parse_error,
+      incident_age_minutes: incidentAgeProfile.age_minutes,
+      incident_age_band: incidentAgeProfile.band,
+      incident_age_warning_minutes: incidentAgeProfile.warning_minutes,
+      incident_age_critical_minutes: incidentAgeProfile.critical_minutes,
+      incident_age_escalation_due: incidentAgeProfile.escalation_due,
+      incident_first_seen_at_utc: incidentAgeProfile.first_seen_at_utc,
       ack_sla_minutes: ackMarker.ack_sla_minutes,
       ack_due_at_utc: ackMarker.ack_due_at_utc,
       ack_due_at_et: ackMarker.ack_due_at_et,
@@ -1000,6 +1117,9 @@ async function main() {
     ack_digest_json_path: path.relative(process.cwd(), digestJsonPath),
     ack_digest_md_path: path.relative(process.cwd(), digestMdPath),
     dispatch_alert_summary_json_path: path.relative(process.cwd(), summaryJsonPath),
+    incident_age_minutes: String(incidentAgeProfile.age_minutes),
+    incident_age_band: incidentAgeProfile.band,
+    incident_age_escalation_due: String(incidentAgeProfile.escalation_due),
     escalation_enabled: String(escalationEnabled),
     drift_escalation_enabled: String(driftEscalationEnabled),
     ack_reminders_due_count: String(reminderSummary.length),


### PR DESCRIPTION
## Summary
Implements live-ops phase 10 fallback scope from #129 via focused issue #130.

### What changed
- `scripts/ci/dispatch-hybrid-alert.mjs`
  - Added deterministic incident-age profiling (`new|fresh|aging|critical`) using configurable thresholds.
  - Added quality-drift ACK policy tuning overlays based on incident age.
  - Added `incident_age_band` policy-node support in `ALERT_ACK_ESCALATION_POLICY_JSON`.
  - Added incident-age metadata into alert text, alert metadata payload, escalation summary contract, dispatch summary JSON, digest JSON/MD, and GitHub step outputs.
- `.github/workflows/hybrid-daily-pipeline.yml`
  - Added workflow-dispatch inputs: `incident_age_warning_minutes`, `incident_age_critical_minutes`.
  - Wired canary/live dispatch env values for incident-age controls with repo-variable fallbacks.
- `db/README.md`, `docs/RUNBOOK_DEPLOY_GENERIC.md`
  - Documented new incident-age controls, policy schema, and payload metadata contract fields.

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- workflow YAML parse check (`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hybrid-daily-pipeline.yml")'`)
- `npm run md:audit:strict`
- dry-run dispatcher verification for incident-age fields in emitted artifacts.

Closes #130