### PR TITLE
feat(live-ops): phase-12 quality ACK incident routing + metadata

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -213,6 +213,10 @@ jobs:
             const fallback = {
               quality_signal_count: "0",
               quality_severity_score: "0",
+              quality_failure_mode_rehearsal_breach_count: "0",
+              quality_stakeholder_proof_request_breach_count: "0",
+              quality_phase12_top_breach_kind: "",
+              quality_phase12_gate_breached: "false",
               quality_top_lane: "",
               quality_top_lane_severity: "",
               quality_gate_breached: "false",
@@ -243,11 +247,22 @@ jobs:
             const lanes = Array.isArray(prep.escalation_lanes) ? prep.escalation_lanes : [];
             const lane = lanes[0] || {};
             const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
-            const qualityGateBreached = breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const failureModeRehearsalBreachCount = breaches.filter((b) => b?.kind === "quality_failure_mode_rehearsal_coverage_pct").length;
+            const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
+            const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
+            const qualityGateBreached = qualityPhase12GateBreached || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const qualityPhase12TopBreachKind =
+              failureModeRehearsalBreachCount >= stakeholderProofRequestBreachCount
+                ? (failureModeRehearsalBreachCount > 0 ? "quality_failure_mode_rehearsal_coverage_pct" : "")
+                : "quality_stakeholder_proof_request_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
               quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
+              quality_failure_mode_rehearsal_breach_count: String(failureModeRehearsalBreachCount),
+              quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
+              quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
+              quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
               quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
               quality_gate_breached: qualityGateBreached ? "true" : "false",
@@ -324,6 +339,10 @@ jobs:
           MAX_ARTIFACT_ISSUES: ${{ env.MAX_ARTIFACT_ISSUES_INPUT }}
           ALERT_QUALITY_DRIFT_SIGNAL_COUNT: ${{ steps.quality.outputs.quality_signal_count }}
           ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
+          ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT: ${{ steps.quality.outputs.quality_failure_mode_rehearsal_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
+          ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
+          ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
           ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
           ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}
@@ -564,6 +583,10 @@ jobs:
             const fallback = {
               quality_signal_count: "0",
               quality_severity_score: "0",
+              quality_failure_mode_rehearsal_breach_count: "0",
+              quality_stakeholder_proof_request_breach_count: "0",
+              quality_phase12_top_breach_kind: "",
+              quality_phase12_gate_breached: "false",
               quality_top_lane: "",
               quality_top_lane_severity: "",
               quality_gate_breached: "false",
@@ -594,11 +617,22 @@ jobs:
             const lanes = Array.isArray(prep.escalation_lanes) ? prep.escalation_lanes : [];
             const lane = lanes[0] || {};
             const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
-            const qualityGateBreached = breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const failureModeRehearsalBreachCount = breaches.filter((b) => b?.kind === "quality_failure_mode_rehearsal_coverage_pct").length;
+            const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
+            const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
+            const qualityGateBreached = qualityPhase12GateBreached || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const qualityPhase12TopBreachKind =
+              failureModeRehearsalBreachCount >= stakeholderProofRequestBreachCount
+                ? (failureModeRehearsalBreachCount > 0 ? "quality_failure_mode_rehearsal_coverage_pct" : "")
+                : "quality_stakeholder_proof_request_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
               quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
+              quality_failure_mode_rehearsal_breach_count: String(failureModeRehearsalBreachCount),
+              quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
+              quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
+              quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
               quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
               quality_gate_breached: qualityGateBreached ? "true" : "false",
@@ -771,6 +805,10 @@ jobs:
           ALERT_DRIFT_MD: ${{ steps.drift.outputs.drift_md_path }}
           ALERT_QUALITY_DRIFT_SIGNAL_COUNT: ${{ steps.quality.outputs.quality_signal_count }}
           ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
+          ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT: ${{ steps.quality.outputs.quality_failure_mode_rehearsal_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
+          ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
+          ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
           ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
           ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}

--- a/db/README.md
+++ b/db/README.md
@@ -320,7 +320,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -393,6 +393,10 @@ Runtime notes:
       - `quality_drift_signal_count`
       - `quality_severity_score`
       - `quality_gate_breached`
+      - `quality_phase12_gate_breached`
+      - `quality_failure_mode_rehearsal_breach_count`
+      - `quality_stakeholder_proof_request_breach_count`
+      - `quality_phase12_top_breach_kind`
       - `quality_top_lane`
       - `quality_top_lane_severity`
   - dispatcher persists ACK state to `ALERT_ACK_STATE_PATH` and reconciles acknowledged incidents via marker/key evidence on subsequent runs

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -304,7 +304,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -362,6 +362,7 @@ Include:
       - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`, `ack_policy_applied`, `ack_policy_parse_error`)
       - deterministic incident-age metadata (`incident_age_minutes`, `incident_age_band`, `incident_age_warning_minutes`, `incident_age_critical_minutes`, `incident_age_escalation_due`, `incident_first_seen_at_utc`)
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
+      - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
       - ACK stale-expiry metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`)
       - ACK evidence-ingestion metadata (`ack_evidence_active_marker_count`, `ack_evidence_active_key_count`, `ack_evidence_stale_entry_count`, `ack_evidence_parse_error_count`, `ack_evidence_json`)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -197,15 +197,25 @@ function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualityPhase12GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED);
   const qualitySignalCount = Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "0");
+  const qualityPhase12BreachCount =
+    Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase12GateBreached) {
+    return { type: "quality_phase12_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityGateBreached) {
     return { type: "quality_drift_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase12BreachCount) && qualityPhase12BreachCount > 0) {
+    return { type: "quality_phase12_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualitySignalCount) && qualitySignalCount > 0) {
     return { type: "quality_drift_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -253,6 +263,10 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
+  } else if (incident.type === "quality_phase12_gate_breach") {
+    defaults.ack_sla_minutes = 15;
+    defaults.ack_reminder_interval_minutes = 15;
+    defaults.ack_escalate_after_reminders = 1;
   } else if (incident.type === "quality_drift_gate_breach") {
     defaults.ack_sla_minutes = 20;
     defaults.ack_reminder_interval_minutes = 20;
@@ -261,6 +275,8 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
+  } else if (incident.type === "quality_phase12_signal_detected") {
+    defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
   }
@@ -710,6 +726,10 @@ function buildAlertText({
   const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
   const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
   const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityPhase12GateBreached = process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED || "";
+  const qualityFailureModeRehearsalBreachCount = process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "";
+  const qualityStakeholderProofRequestBreachCount = process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "";
+  const qualityPhase12TopBreachKind = process.env.ALERT_QUALITY_PHASE12_TOP_BREACH_KIND || "";
   const qualityTopLane = process.env.ALERT_QUALITY_TOP_LANE || "";
   const qualityTopLaneSeverity = process.env.ALERT_QUALITY_TOP_LANE_SEVERITY || "";
 
@@ -758,12 +778,16 @@ function buildAlertText({
     qualitySignals ||
     qualitySeverityScore ||
     qualityGateBreached ||
+    qualityPhase12GateBreached ||
+    qualityFailureModeRehearsalBreachCount ||
+    qualityStakeholderProofRequestBreachCount ||
+    qualityPhase12TopBreachKind ||
     qualityTopLane ||
     qualityTopLaneSeverity ||
     incident.quality_related
   ) {
     lines.push(
-      `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+      `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
     );
   }
   if (
@@ -1071,6 +1095,10 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_failure_mode_rehearsal_breach_count: Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || 0),
+      quality_stakeholder_proof_request_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || 0),
+      quality_phase12_top_breach_kind: process.env.ALERT_QUALITY_PHASE12_TOP_BREACH_KIND || null,
       quality_top_lane: process.env.ALERT_QUALITY_TOP_LANE || null,
       quality_top_lane_severity: process.env.ALERT_QUALITY_TOP_LANE_SEVERITY || null,
     },
@@ -1125,6 +1153,15 @@ async function main() {
     ack_evidence_contract: ackEvidenceContract,
     ack_sla_reminder_contract: ackSlaReminderContract,
     escalation_summary: escalationSummary,
+    quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
+    quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
+    quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_failure_mode_rehearsal_breach_count: Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || 0),
+    quality_stakeholder_proof_request_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || 0),
+    quality_phase12_top_breach_kind: process.env.ALERT_QUALITY_PHASE12_TOP_BREACH_KIND || null,
+    quality_top_lane: process.env.ALERT_QUALITY_TOP_LANE || null,
+    quality_top_lane_severity: process.env.ALERT_QUALITY_TOP_LANE_SEVERITY || null,
     dry_run: dryRun,
   };
 


### PR DESCRIPTION
## Summary
- extend hybrid daily workflow quality extraction (canary + live) with phase-12 breach context:
  - `quality_failure_mode_rehearsal_breach_count`
  - `quality_stakeholder_proof_request_breach_count`
  - `quality_phase12_top_breach_kind`
  - `quality_phase12_gate_breached`
- pass new quality outputs into alert-dispatch env for both canary/live lanes
- extend alert dispatcher incident classification:
  - `quality_phase12_signal_detected`
  - `quality_phase12_gate_breach`
- add ACK policy defaults for new phase-12 incident types
- harden alert text + metadata + summary payloads with phase-12 quality breach fields
- update `db/README.md` and `docs/RUNBOOK_DEPLOY_GENERIC.md` incident-type/schema docs

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hybrid-daily-pipeline.yml"); puts "workflow_yaml_ok"'`
- dispatcher dry-run with phase-12 gate env:
  - `ALERT_QUALITY_PHASE12_GATE_BREACHED=true`
  - `ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT=1`
  - result confirmed `incident_type=quality_phase12_gate_breach` plus new phase-12 metadata fields
- `npm run md:audit:strict`

Closes #148