### PR TITLE
feat(live-ops): phase-13 quality incident typing + ACK policy tuning

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -215,8 +215,12 @@ jobs:
               quality_severity_score: "0",
               quality_failure_mode_rehearsal_breach_count: "0",
               quality_stakeholder_proof_request_breach_count: "0",
+              quality_confidence_calibration_breach_count: "0",
+              quality_owner_assignment_breach_count: "0",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
+              quality_phase13_top_breach_kind: "",
+              quality_phase13_gate_breached: "false",
               quality_top_lane: "",
               quality_top_lane_severity: "",
               quality_gate_breached: "false",
@@ -249,20 +253,33 @@ jobs:
             const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
             const failureModeRehearsalBreachCount = breaches.filter((b) => b?.kind === "quality_failure_mode_rehearsal_coverage_pct").length;
             const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
+            const confidenceCalibrationBreachCount = breaches.filter((b) => b?.kind === "quality_confidence_calibration_drop").length;
+            const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
-            const qualityGateBreached = qualityPhase12GateBreached || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
+            const qualityGateBreached = qualityPhase12GateBreached
+              || qualityPhase13GateBreached
+              || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
             const qualityPhase12TopBreachKind =
               failureModeRehearsalBreachCount >= stakeholderProofRequestBreachCount
                 ? (failureModeRehearsalBreachCount > 0 ? "quality_failure_mode_rehearsal_coverage_pct" : "")
                 : "quality_stakeholder_proof_request_coverage_pct";
+            const qualityPhase13TopBreachKind =
+              confidenceCalibrationBreachCount >= ownerAssignmentBreachCount
+                ? (confidenceCalibrationBreachCount > 0 ? "quality_confidence_calibration_drop" : "")
+                : "quality_owner_assignment_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
               quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
               quality_failure_mode_rehearsal_breach_count: String(failureModeRehearsalBreachCount),
               quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
+              quality_confidence_calibration_breach_count: String(confidenceCalibrationBreachCount),
+              quality_owner_assignment_breach_count: String(ownerAssignmentBreachCount),
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
+              quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
+              quality_phase13_gate_breached: qualityPhase13GateBreached ? "true" : "false",
               quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
               quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
               quality_gate_breached: qualityGateBreached ? "true" : "false",
@@ -341,8 +358,12 @@ jobs:
           ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
           ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT: ${{ steps.quality.outputs.quality_failure_mode_rehearsal_breach_count }}
           ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
+          ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT: ${{ steps.quality.outputs.quality_confidence_calibration_breach_count }}
+          ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT: ${{ steps.quality.outputs.quality_owner_assignment_breach_count }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
+          ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
+          ALERT_QUALITY_PHASE13_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase13_gate_breached }}
           ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
           ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
           ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}
@@ -585,8 +606,12 @@ jobs:
               quality_severity_score: "0",
               quality_failure_mode_rehearsal_breach_count: "0",
               quality_stakeholder_proof_request_breach_count: "0",
+              quality_confidence_calibration_breach_count: "0",
+              quality_owner_assignment_breach_count: "0",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
+              quality_phase13_top_breach_kind: "",
+              quality_phase13_gate_breached: "false",
               quality_top_lane: "",
               quality_top_lane_severity: "",
               quality_gate_breached: "false",
@@ -619,20 +644,33 @@ jobs:
             const breaches = Array.isArray(parsed?.breaches) ? parsed.breaches : [];
             const failureModeRehearsalBreachCount = breaches.filter((b) => b?.kind === "quality_failure_mode_rehearsal_coverage_pct").length;
             const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
+            const confidenceCalibrationBreachCount = breaches.filter((b) => b?.kind === "quality_confidence_calibration_drop").length;
+            const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
-            const qualityGateBreached = qualityPhase12GateBreached || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
+            const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
+            const qualityGateBreached = qualityPhase12GateBreached
+              || qualityPhase13GateBreached
+              || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
             const qualityPhase12TopBreachKind =
               failureModeRehearsalBreachCount >= stakeholderProofRequestBreachCount
                 ? (failureModeRehearsalBreachCount > 0 ? "quality_failure_mode_rehearsal_coverage_pct" : "")
                 : "quality_stakeholder_proof_request_coverage_pct";
+            const qualityPhase13TopBreachKind =
+              confidenceCalibrationBreachCount >= ownerAssignmentBreachCount
+                ? (confidenceCalibrationBreachCount > 0 ? "quality_confidence_calibration_drop" : "")
+                : "quality_owner_assignment_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
               quality_severity_score: Number.isFinite(severityScore) ? String(severityScore) : "0",
               quality_failure_mode_rehearsal_breach_count: String(failureModeRehearsalBreachCount),
               quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
+              quality_confidence_calibration_breach_count: String(confidenceCalibrationBreachCount),
+              quality_owner_assignment_breach_count: String(ownerAssignmentBreachCount),
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
+              quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
+              quality_phase13_gate_breached: qualityPhase13GateBreached ? "true" : "false",
               quality_top_lane: typeof lane.lane === "string" ? lane.lane : "",
               quality_top_lane_severity: typeof lane.severity === "string" ? lane.severity : "",
               quality_gate_breached: qualityGateBreached ? "true" : "false",
@@ -807,8 +845,12 @@ jobs:
           ALERT_QUALITY_SEVERITY_SCORE: ${{ steps.quality.outputs.quality_severity_score }}
           ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT: ${{ steps.quality.outputs.quality_failure_mode_rehearsal_breach_count }}
           ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
+          ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT: ${{ steps.quality.outputs.quality_confidence_calibration_breach_count }}
+          ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT: ${{ steps.quality.outputs.quality_owner_assignment_breach_count }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
+          ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
+          ALERT_QUALITY_PHASE13_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase13_gate_breached }}
           ALERT_QUALITY_TOP_LANE: ${{ steps.quality.outputs.quality_top_lane }}
           ALERT_QUALITY_TOP_LANE_SEVERITY: ${{ steps.quality.outputs.quality_top_lane_severity }}
           ALERT_QUALITY_GATE_BREACHED: ${{ steps.quality.outputs.quality_gate_breached }}

--- a/db/README.md
+++ b/db/README.md
@@ -323,7 +323,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -396,6 +396,10 @@ Runtime notes:
       - `quality_drift_signal_count`
       - `quality_severity_score`
       - `quality_gate_breached`
+      - `quality_phase13_gate_breached`
+      - `quality_confidence_calibration_breach_count`
+      - `quality_owner_assignment_breach_count`
+      - `quality_phase13_top_breach_kind`
       - `quality_phase12_gate_breached`
       - `quality_failure_mode_rehearsal_breach_count`
       - `quality_stakeholder_proof_request_breach_count`

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -307,7 +307,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -365,6 +365,7 @@ Include:
       - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`, `ack_policy_applied`, `ack_policy_parse_error`)
       - deterministic incident-age metadata (`incident_age_minutes`, `incident_age_band`, `incident_age_warning_minutes`, `incident_age_critical_minutes`, `incident_age_escalation_due`, `incident_first_seen_at_utc`)
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
+      - phase-13 quality breach metadata (`quality_phase13_gate_breached`, `quality_confidence_calibration_breach_count`, `quality_owner_assignment_breach_count`, `quality_phase13_top_breach_kind`)
       - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
       - ACK stale-expiry metadata (`ack_stale_after_minutes`, `ack_stale_pending_count`, `ack_newly_stale_count`)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -198,12 +198,19 @@ function classifyIncident() {
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
   const qualityPhase12GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED);
+  const qualityPhase13GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED);
   const qualitySignalCount = Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "0");
   const qualityPhase12BreachCount =
     Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "0");
+  const qualityPhase13BreachCount =
+    Number(process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase13GateBreached) {
+    return { type: "quality_phase13_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityPhase12GateBreached) {
     return { type: "quality_phase12_gate_breach", drift_related: false, quality_related: true, severity: "high" };
@@ -213,6 +220,9 @@ function classifyIncident() {
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase13BreachCount) && qualityPhase13BreachCount > 0) {
+    return { type: "quality_phase13_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualityPhase12BreachCount) && qualityPhase12BreachCount > 0) {
     return { type: "quality_phase12_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -263,7 +273,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
-  } else if (incident.type === "quality_phase12_gate_breach") {
+  } else if (incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
@@ -275,7 +285,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
-  } else if (incident.type === "quality_phase12_signal_detected") {
+  } else if (incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
     defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
@@ -726,6 +736,10 @@ function buildAlertText({
   const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
   const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
   const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityPhase13GateBreached = process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED || "";
+  const qualityConfidenceCalibrationBreachCount = process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || "";
+  const qualityOwnerAssignmentBreachCount = process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "";
+  const qualityPhase13TopBreachKind = process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || "";
   const qualityPhase12GateBreached = process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED || "";
   const qualityFailureModeRehearsalBreachCount = process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "";
   const qualityStakeholderProofRequestBreachCount = process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "";
@@ -778,6 +792,10 @@ function buildAlertText({
     qualitySignals ||
     qualitySeverityScore ||
     qualityGateBreached ||
+    qualityPhase13GateBreached ||
+    qualityConfidenceCalibrationBreachCount ||
+    qualityOwnerAssignmentBreachCount ||
+    qualityPhase13TopBreachKind ||
     qualityPhase12GateBreached ||
     qualityFailureModeRehearsalBreachCount ||
     qualityStakeholderProofRequestBreachCount ||
@@ -788,6 +806,9 @@ function buildAlertText({
   ) {
     lines.push(
       `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
+    lines.push(
+      `Meeting-prep quality phase13: gateBreached=${qualityPhase13GateBreached || "n/a"}, confidenceCalibrationBreaches=${qualityConfidenceCalibrationBreachCount || "0"}, ownerAssignmentBreaches=${qualityOwnerAssignmentBreachCount || "0"}, phase13TopBreachKind=${qualityPhase13TopBreachKind || "n/a"}`
     );
   }
   if (
@@ -1095,7 +1116,11 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
       quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_confidence_calibration_breach_count: Number(process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || 0),
+      quality_owner_assignment_breach_count: Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || 0),
+      quality_phase13_top_breach_kind: process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || null,
       quality_failure_mode_rehearsal_breach_count: Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || 0),
       quality_stakeholder_proof_request_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || 0),
       quality_phase12_top_breach_kind: process.env.ALERT_QUALITY_PHASE12_TOP_BREACH_KIND || null,
@@ -1156,7 +1181,11 @@ async function main() {
     quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
     quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
     quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
     quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_confidence_calibration_breach_count: Number(process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || 0),
+    quality_owner_assignment_breach_count: Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || 0),
+    quality_phase13_top_breach_kind: process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || null,
     quality_failure_mode_rehearsal_breach_count: Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || 0),
     quality_stakeholder_proof_request_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || 0),
     quality_phase12_top_breach_kind: process.env.ALERT_QUALITY_PHASE12_TOP_BREACH_KIND || null,


### PR DESCRIPTION
## Summary
Implements live ops phase 13 from #157.

### What changed
- Extended workflow quality extraction in both canary and live lanes (`.github/workflows/hybrid-daily-pipeline.yml`) to surface phase-13 breach context:
  - `quality_confidence_calibration_breach_count`
  - `quality_owner_assignment_breach_count`
  - `quality_phase13_top_breach_kind`
  - `quality_phase13_gate_breached`
- Wired new phase-13 outputs into alert dispatch env vars for both lanes.
- Updated `scripts/ci/dispatch-hybrid-alert.mjs`:
  - deterministic incident typing for phase-13 classes:
    - `quality_phase13_gate_breach`
    - `quality_phase13_signal_detected`
  - ACK policy defaults tuned for phase-13 incidents (aligned with phase-12 criticality behavior).
  - metadata + summary payloads expanded with phase-13 breach fields.
  - human-readable alert text now includes phase-13 breach context line.
- Updated operator docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`
  - incident type policy schema now includes phase-13 incident keys.

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- YAML parse check for `.github/workflows/hybrid-daily-pipeline.yml`
- `npm run md:audit:strict`
- dispatcher dry-run with phase-13 gate inputs:
  - confirmed `incident_type=quality_phase13_gate_breach`
  - confirmed phase-13 metadata in summary artifact

Closes #157