### PR TITLE
feat(health): add phase-14 quality drift gates for counterfactual/handoff coverage

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -288,6 +288,8 @@ Runtime notes:
       - `--min-quality-failure-mode-rehearsal-coverage-pct <n>`
       - `--min-quality-stakeholder-proof-request-coverage-pct <n>`
       - `--min-quality-owner-assignment-coverage-pct <n>`
+      - `--min-quality-counterfactual-decision-drill-coverage-pct <n>`
+      - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
 - Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
 - Live lane also runs canary-vs-live drift comparison after health report generation:
   - resolves latest same-date canary artifact (`hybrid-daily-canary-YYYY-MM-DD`) via GitHub Actions artifact API
@@ -537,6 +539,8 @@ Optional flags:
   - `--min-quality-failure-mode-rehearsal-coverage-pct <n>`
   - `--min-quality-stakeholder-proof-request-coverage-pct <n>`
   - `--min-quality-owner-assignment-coverage-pct <n>`
+  - `--min-quality-counterfactual-decision-drill-coverage-pct <n>`
+  - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
 
 Threshold-gated example (CI/alerts):
 ```bash
@@ -572,7 +576,9 @@ npm run db:hybrid:health -- \
   --min-quality-close-scripts-coverage-pct 0 \
   --min-quality-failure-mode-rehearsal-coverage-pct 0 \
   --min-quality-stakeholder-proof-request-coverage-pct 0 \
-  --min-quality-owner-assignment-coverage-pct 0
+  --min-quality-owner-assignment-coverage-pct 0 \
+  --min-quality-counterfactual-decision-drill-coverage-pct 0 \
+  --min-quality-stakeholder-objection-handoff-coverage-pct 0
 ```
 
 Exit behavior:
@@ -613,8 +619,8 @@ Output includes:
   - aggregates breach events by severity and source/top breach kinds
 - threshold metadata (`thresholds`) and explicit breach records (`breaches`)
 - meeting-prep quality trendline drift analysis from `artifacts/meeting-prep-quality-*.json` and `artifacts/meeting-prep-phase*.json`:
-  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`)
-  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`)
+  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`)
+  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`, `counterfactual_decision_drill_coverage_drop`, `stakeholder_objection_handoff_coverage_drop`)
   - deterministic escalation lanes by latest gap severity (`immediate_owner_escalation`, `same_day_quality_remediation`, `next_cycle_hardening`, `monitor_only`)
 - trend artifact export metadata (`trend_artifacts`) with written/pruned file paths when enabled
 - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned file paths when enabled

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -466,6 +466,8 @@ Include:
     - `--min-quality-failure-mode-rehearsal-coverage-pct <n>`
     - `--min-quality-stakeholder-proof-request-coverage-pct <n>`
     - `--min-quality-owner-assignment-coverage-pct <n>`
+    - `--min-quality-counterfactual-decision-drill-coverage-pct <n>`
+    - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
 - Report fields include:
   - source cursor lag/drift for `gmail`, `google_calendar`, and `kb_ingest`
   - entity/chunk coverage totals and grouped `domain/type` counts
@@ -499,7 +501,7 @@ Include:
   - meeting-prep quality trendline drift analysis:
     - scans `meeting-prep-quality-*.json` + `meeting-prep-phase*.json`
     - emits deterministic drift signals and severity-based escalation lanes
-    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`)
+    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`)
   - trend artifact export metadata (`trend_artifacts`) with written/pruned files when export is enabled
   - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned files when export is enabled
 
@@ -537,7 +539,9 @@ npm run db:hybrid:health -- \
   --min-quality-close-scripts-coverage-pct 0 \
   --min-quality-failure-mode-rehearsal-coverage-pct 0 \
   --min-quality-stakeholder-proof-request-coverage-pct 0 \
-  --min-quality-owner-assignment-coverage-pct 0
+  --min-quality-owner-assignment-coverage-pct 0 \
+  --min-quality-counterfactual-decision-drill-coverage-pct 0 \
+  --min-quality-stakeholder-objection-handoff-coverage-pct 0
 ```
 
 Exit behavior:

--- a/scripts/db/hybrid-ingestion-health.mjs
+++ b/scripts/db/hybrid-ingestion-health.mjs
@@ -62,6 +62,8 @@ const thresholds = {
   min_quality_failure_mode_rehearsal_coverage_pct: readOptionalNumberArg(args, '--min-quality-failure-mode-rehearsal-coverage-pct'),
   min_quality_stakeholder_proof_request_coverage_pct: readOptionalNumberArg(args, '--min-quality-stakeholder-proof-request-coverage-pct'),
   min_quality_owner_assignment_coverage_pct: readOptionalNumberArg(args, '--min-quality-owner-assignment-coverage-pct'),
+  min_quality_counterfactual_decision_drill_coverage_pct: readOptionalNumberArg(args, '--min-quality-counterfactual-decision-drill-coverage-pct'),
+  min_quality_stakeholder_objection_handoff_coverage_pct: readOptionalNumberArg(args, '--min-quality-stakeholder-objection-handoff-coverage-pct'),
 };
 const hasThresholds = Object.values(thresholds).some((value) => value !== null);
 
@@ -473,9 +475,9 @@ function printMarkdown(result, artifactDirInput) {
   } else {
     console.log(`- scanned_artifacts=${result.meeting_prep_quality.scanned_artifacts}, snapshots=${result.meeting_prep_quality.snapshots}, meetings_scored=${result.meeting_prep_quality.meetings_scored}`);
     console.log(`- latest_avg_score=${formatNumber(result.meeting_prep_quality.latest?.avg_score)}, latest_avg_gap_count=${formatNumber(result.meeting_prep_quality.latest?.avg_gap_count)}, latest_severity_score=${formatNumber(result.meeting_prep_quality.latest?.severity_score)}`);
-    console.log(`- latest_readiness_score=${formatNumber(result.meeting_prep_quality.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.owner_assignment_coverage_pct)}`);
+    console.log(`- latest_readiness_score=${formatNumber(result.meeting_prep_quality.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_objection_handoff_coverage_pct)}`);
     console.log(`- oldest_avg_score=${formatNumber(result.meeting_prep_quality.oldest?.avg_score)}, oldest_avg_gap_count=${formatNumber(result.meeting_prep_quality.oldest?.avg_gap_count)}, oldest_severity_score=${formatNumber(result.meeting_prep_quality.oldest?.severity_score)}`);
-    console.log(`- oldest_readiness_score=${formatNumber(result.meeting_prep_quality.oldest?.readiness_score)}, oldest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.narrative_coverage_pct)}, oldest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.dependency_coverage_pct)}, oldest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.decision_sequencing_coverage_pct)}, oldest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.close_scripts_coverage_pct)}, oldest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.failure_mode_rehearsal_coverage_pct)}, oldest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_proof_request_coverage_pct)}, oldest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_coverage_pct)}, oldest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_avg_delta)}, oldest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.owner_assignment_coverage_pct)}`);
+    console.log(`- oldest_readiness_score=${formatNumber(result.meeting_prep_quality.oldest?.readiness_score)}, oldest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.narrative_coverage_pct)}, oldest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.dependency_coverage_pct)}, oldest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.decision_sequencing_coverage_pct)}, oldest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.close_scripts_coverage_pct)}, oldest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.failure_mode_rehearsal_coverage_pct)}, oldest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_proof_request_coverage_pct)}, oldest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_coverage_pct)}, oldest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_avg_delta)}, oldest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.owner_assignment_coverage_pct)}, oldest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.counterfactual_decision_drill_coverage_pct)}, oldest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_objection_handoff_coverage_pct)}`);
 
     const driftSignals = Array.isArray(result.meeting_prep_quality.drift_signals) ? result.meeting_prep_quality.drift_signals : [];
     if (!driftSignals.length) {
@@ -599,6 +601,8 @@ function printMarkdown(result, artifactDirInput) {
   console.log(`- min_quality_failure_mode_rehearsal_coverage_pct=${formatNumber(result.thresholds.min_quality_failure_mode_rehearsal_coverage_pct)}`);
   console.log(`- min_quality_stakeholder_proof_request_coverage_pct=${formatNumber(result.thresholds.min_quality_stakeholder_proof_request_coverage_pct)}`);
   console.log(`- min_quality_owner_assignment_coverage_pct=${formatNumber(result.thresholds.min_quality_owner_assignment_coverage_pct)}`);
+  console.log(`- min_quality_counterfactual_decision_drill_coverage_pct=${formatNumber(result.thresholds.min_quality_counterfactual_decision_drill_coverage_pct)}`);
+  console.log(`- min_quality_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.thresholds.min_quality_stakeholder_objection_handoff_coverage_pct)}`);
   console.log(`- breaches=${result.breaches.length}`);
 
   if (!result.breaches.length) {
@@ -673,6 +677,14 @@ function printMarkdown(result, artifactDirInput) {
     }
     if (breach.kind === 'quality_owner_assignment_coverage_pct') {
       console.log(`- [breach] quality owner-assignment coverage: actual=${breach.actual} < minimum=${breach.limit}`);
+      continue;
+    }
+    if (breach.kind === 'quality_counterfactual_decision_drill_coverage_pct') {
+      console.log(`- [breach] quality counterfactual decision-drill coverage: actual=${breach.actual} < minimum=${breach.limit}`);
+      continue;
+    }
+    if (breach.kind === 'quality_stakeholder_objection_handoff_coverage_pct') {
+      console.log(`- [breach] quality stakeholder objection-handoff coverage: actual=${breach.actual} < minimum=${breach.limit}`);
       continue;
     }
     console.log(`- [breach] ${breach.source} ${breach.kind}: actual=${breach.actual} > limit=${breach.limit}`);
@@ -1400,6 +1412,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
     let failureModeRehearsalCovered = 0;
     let stakeholderProofRequestCovered = 0;
     let confidenceCalibrationCovered = 0;
+    let counterfactualDecisionDrillCovered = 0;
+    let stakeholderObjectionHandoffCovered = 0;
     const confidenceCalibrationDeltas = [];
     const ownerAssignmentCoveragePcts = [];
     const readinessScores = [];
@@ -1415,6 +1429,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       const failureModeRehearsalComplete = hasFailureModeRehearsals(meeting?.failureModeRehearsals);
       const stakeholderProofRequestComplete = hasStakeholderProofRequests(meeting?.stakeholderProofRequests);
       const confidenceCalibrationComplete = hasConfidenceCalibrationTrend(meeting?.confidenceCalibrationTrend);
+      const counterfactualDecisionDrillComplete = hasCounterfactualDecisionDrillPrompts(meeting?.counterfactualDecisionDrillPrompts);
+      const stakeholderObjectionHandoffComplete = hasStakeholderObjectionResponseHandoffMap(meeting?.stakeholderObjectionResponseHandoffMap);
       const ownerAssignmentCoveragePct = computeOwnerAssignmentCoveragePct({
         balancing: meeting?.actionOwnerLoadBalancing,
         meetingRecommendations: meeting?.meetingRecommendations,
@@ -1426,6 +1442,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       if (closeScriptsComplete) closeScriptsCovered += 1;
       if (failureModeRehearsalComplete) failureModeRehearsalCovered += 1;
       if (stakeholderProofRequestComplete) stakeholderProofRequestCovered += 1;
+      if (counterfactualDecisionDrillComplete) counterfactualDecisionDrillCovered += 1;
+      if (stakeholderObjectionHandoffComplete) stakeholderObjectionHandoffCovered += 1;
       if (confidenceCalibrationComplete) {
         confidenceCalibrationCovered += 1;
         confidenceCalibrationDeltas.push(Number(meeting?.confidenceCalibrationTrend?.averageDelta || 0));
@@ -1450,6 +1468,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
     const failureModeRehearsalCoveragePct = Number(((failureModeRehearsalCovered / scored.length) * 100).toFixed(3));
     const stakeholderProofRequestCoveragePct = Number(((stakeholderProofRequestCovered / scored.length) * 100).toFixed(3));
     const confidenceCalibrationCoveragePct = Number(((confidenceCalibrationCovered / scored.length) * 100).toFixed(3));
+    const counterfactualDecisionDrillCoveragePct = Number(((counterfactualDecisionDrillCovered / scored.length) * 100).toFixed(3));
+    const stakeholderObjectionHandoffCoveragePct = Number(((stakeholderObjectionHandoffCovered / scored.length) * 100).toFixed(3));
     const confidenceCalibrationAvgDelta = confidenceCalibrationDeltas.length
       ? Number((confidenceCalibrationDeltas.reduce((sum, value) => sum + value, 0) / confidenceCalibrationDeltas.length).toFixed(3))
       : null;
@@ -1484,6 +1504,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       confidence_calibration_coverage_pct: confidenceCalibrationCoveragePct,
       confidence_calibration_avg_delta: confidenceCalibrationAvgDelta,
       owner_assignment_coverage_pct: ownerAssignmentCoveragePct,
+      counterfactual_decision_drill_coverage_pct: counterfactualDecisionDrillCoveragePct,
+      stakeholder_objection_handoff_coverage_pct: stakeholderObjectionHandoffCoveragePct,
       narrative_covered_count: narrativeCovered,
       dependency_covered_count: dependencyCovered,
       sequencing_covered_count: sequencingCovered,
@@ -1491,6 +1513,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       failure_mode_rehearsal_covered_count: failureModeRehearsalCovered,
       stakeholder_proof_request_covered_count: stakeholderProofRequestCovered,
       confidence_calibration_covered_count: confidenceCalibrationCovered,
+      counterfactual_decision_drill_covered_count: counterfactualDecisionDrillCovered,
+      stakeholder_objection_handoff_covered_count: stakeholderObjectionHandoffCovered,
       severity_score: severityScore,
       levels: levelCounts,
       failing_check_severity: severityCounts,
@@ -1545,6 +1569,8 @@ function buildMeetingPrepQualityDriftSignals({ oldest, latest }) {
   const confidenceCalibrationCoverageDelta = Number((Number(latest.confidence_calibration_coverage_pct || 0) - Number(oldest.confidence_calibration_coverage_pct || 0)).toFixed(3));
   const confidenceCalibrationAvgDeltaDelta = Number((Number(latest.confidence_calibration_avg_delta || 0) - Number(oldest.confidence_calibration_avg_delta || 0)).toFixed(3));
   const ownerAssignmentCoverageDelta = Number((Number(latest.owner_assignment_coverage_pct || 0) - Number(oldest.owner_assignment_coverage_pct || 0)).toFixed(3));
+  const counterfactualDecisionDrillCoverageDelta = Number((Number(latest.counterfactual_decision_drill_coverage_pct || 0) - Number(oldest.counterfactual_decision_drill_coverage_pct || 0)).toFixed(3));
+  const stakeholderObjectionHandoffCoverageDelta = Number((Number(latest.stakeholder_objection_handoff_coverage_pct || 0) - Number(oldest.stakeholder_objection_handoff_coverage_pct || 0)).toFixed(3));
   const severityDelta = Number((Number(latest.severity_score || 0) - Number(oldest.severity_score || 0)).toFixed(3));
   const highDelta = Number((Number(latest.failing_check_severity?.high || 0) - Number(oldest.failing_check_severity?.high || 0)).toFixed(3));
 
@@ -1675,6 +1701,24 @@ function buildMeetingPrepQualityDriftSignals({ oldest, latest }) {
     });
   }
 
+  if (counterfactualDecisionDrillCoverageDelta <= -5) {
+    signals.push({
+      code: 'counterfactual_decision_drill_coverage_drop',
+      severity: counterfactualDecisionDrillCoverageDelta <= -30 ? 'high' : counterfactualDecisionDrillCoverageDelta <= -15 ? 'medium' : 'low',
+      delta: counterfactualDecisionDrillCoverageDelta,
+      message: `Counterfactual decision-drill coverage dropped by ${Math.abs(counterfactualDecisionDrillCoverageDelta)} pct vs oldest snapshot.`,
+    });
+  }
+
+  if (stakeholderObjectionHandoffCoverageDelta <= -5) {
+    signals.push({
+      code: 'stakeholder_objection_handoff_coverage_drop',
+      severity: stakeholderObjectionHandoffCoverageDelta <= -30 ? 'high' : stakeholderObjectionHandoffCoverageDelta <= -15 ? 'medium' : 'low',
+      delta: stakeholderObjectionHandoffCoverageDelta,
+      message: `Stakeholder objection-handoff coverage dropped by ${Math.abs(stakeholderObjectionHandoffCoverageDelta)} pct vs oldest snapshot.`,
+    });
+  }
+
   return signals;
 }
 
@@ -1719,6 +1763,8 @@ function buildMeetingPrepQualityEscalationLanes(latestSnapshot) {
   const stakeholderProofRequestCoverage = Number(latestSnapshot.stakeholder_proof_request_coverage_pct || 0);
   const confidenceCalibrationCoverage = Number(latestSnapshot.confidence_calibration_coverage_pct || 0);
   const ownerAssignmentCoverage = Number(latestSnapshot.owner_assignment_coverage_pct || 0);
+  const counterfactualDecisionDrillCoverage = Number(latestSnapshot.counterfactual_decision_drill_coverage_pct || 0);
+  const stakeholderObjectionHandoffCoverage = Number(latestSnapshot.stakeholder_objection_handoff_coverage_pct || 0);
   if (narrativeCoverage < 80) {
     lanes.push({
       lane: 'stakeholder_narrative_pack_remediation',
@@ -1781,6 +1827,22 @@ function buildMeetingPrepQualityEscalationLanes(latestSnapshot) {
       severity: ownerAssignmentCoverage < 60 ? 'high' : 'medium',
       trigger_count: Number(latestSnapshot.scored_meetings || 0),
       message: 'Owner-assignment coverage is below target; require deterministic action-owner balancing before closeout.',
+    });
+  }
+  if (counterfactualDecisionDrillCoverage < 80) {
+    lanes.push({
+      lane: 'counterfactual_decision_drill_remediation',
+      severity: counterfactualDecisionDrillCoverage < 60 ? 'high' : 'medium',
+      trigger_count: Number(latestSnapshot.scored_meetings || 0) - Number(latestSnapshot.counterfactual_decision_drill_covered_count || 0),
+      message: 'Counterfactual decision-drill coverage is below target; require deterministic what-if drills before final closeout.',
+    });
+  }
+  if (stakeholderObjectionHandoffCoverage < 80) {
+    lanes.push({
+      lane: 'stakeholder_objection_handoff_remediation',
+      severity: stakeholderObjectionHandoffCoverage < 60 ? 'high' : 'medium',
+      trigger_count: Number(latestSnapshot.scored_meetings || 0) - Number(latestSnapshot.stakeholder_objection_handoff_covered_count || 0),
+      message: 'Stakeholder objection-handoff coverage is below target; require explicit objection owner/scripts before closeout.',
     });
   }
 
@@ -1854,6 +1916,27 @@ function hasStakeholderProofRequests(requests) {
     const rationale = String(request?.rationale || '').trim();
     const dueWindow = String(request?.dueWindow || '').trim();
     return attendee.length > 0 && proofRequest.length > 0 && rationale.length > 0 && dueWindow.length > 0;
+  });
+}
+
+function hasCounterfactualDecisionDrillPrompts(prompts) {
+  if (!Array.isArray(prompts) || !prompts.length) return false;
+  return prompts.some((drill) => {
+    const scenario = String(drill?.scenario || '').trim();
+    const prompt = String(drill?.prompt || '').trim();
+    const fallback = String(drill?.decisionFallback || '').trim();
+    return scenario.length > 0 && prompt.length > 0 && fallback.length > 0;
+  });
+}
+
+function hasStakeholderObjectionResponseHandoffMap(rows) {
+  if (!Array.isArray(rows) || !rows.length) return false;
+  return rows.some((row) => {
+    const attendee = String(row?.attendee || '').trim();
+    const objectionTheme = String(row?.objectionTheme || '').trim();
+    const responseOwner = String(row?.responseOwner || '').trim();
+    const responseScript = String(row?.responseScript || '').trim();
+    return attendee.length > 0 && objectionTheme.length > 0 && responseOwner.length > 0 && responseScript.length > 0;
   });
 }
 
@@ -2183,6 +2266,8 @@ function evaluateThresholdBreaches({ sources, failures, reconciliation, baseline
     || thresholds.min_quality_failure_mode_rehearsal_coverage_pct !== null
     || thresholds.min_quality_stakeholder_proof_request_coverage_pct !== null
     || thresholds.min_quality_owner_assignment_coverage_pct !== null
+    || thresholds.min_quality_counterfactual_decision_drill_coverage_pct !== null
+    || thresholds.min_quality_stakeholder_objection_handoff_coverage_pct !== null
   ) {
     if (!meetingPrepQuality?.available) {
       breaches.push({
@@ -2318,6 +2403,28 @@ function evaluateThresholdBreaches({ sources, failures, reconciliation, baseline
             kind: 'quality_owner_assignment_coverage_pct',
             actual: latestOwnerAssignmentCoverage,
             limit: thresholds.min_quality_owner_assignment_coverage_pct,
+          });
+        }
+      }
+
+      if (thresholds.min_quality_counterfactual_decision_drill_coverage_pct !== null) {
+        const latestCounterfactualDecisionDrillCoverage = Number(meetingPrepQuality?.latest?.counterfactual_decision_drill_coverage_pct || 0);
+        if (latestCounterfactualDecisionDrillCoverage < thresholds.min_quality_counterfactual_decision_drill_coverage_pct) {
+          breaches.push({
+            kind: 'quality_counterfactual_decision_drill_coverage_pct',
+            actual: latestCounterfactualDecisionDrillCoverage,
+            limit: thresholds.min_quality_counterfactual_decision_drill_coverage_pct,
+          });
+        }
+      }
+
+      if (thresholds.min_quality_stakeholder_objection_handoff_coverage_pct !== null) {
+        const latestStakeholderObjectionHandoffCoverage = Number(meetingPrepQuality?.latest?.stakeholder_objection_handoff_coverage_pct || 0);
+        if (latestStakeholderObjectionHandoffCoverage < thresholds.min_quality_stakeholder_objection_handoff_coverage_pct) {
+          breaches.push({
+            kind: 'quality_stakeholder_objection_handoff_coverage_pct',
+            actual: latestStakeholderObjectionHandoffCoverage,
+            limit: thresholds.min_quality_stakeholder_objection_handoff_coverage_pct,
           });
         }
       }
@@ -2605,7 +2712,7 @@ function severityForBreachKind(kind) {
   if (['lag_hours', 'seen_drift_hours', 'baseline_anomalies_count', 'reconciliation_unavailable', 'slo_budget_unavailable', 'slo_budget_burn_pct', 'meeting_prep_quality_unavailable', 'quality_severity_score', 'quality_readiness_drop', 'quality_confidence_calibration_drop'].includes(k)) {
     return 'high';
   }
-  if (['entity_delta_pct', 'chunk_ratio_delta', 'link_delta_pct', 'artifact_issues_count', 'quality_drift_signals_count', 'quality_narrative_coverage_pct', 'quality_dependency_coverage_pct', 'quality_decision_sequencing_coverage_pct', 'quality_close_scripts_coverage_pct', 'quality_failure_mode_rehearsal_coverage_pct', 'quality_stakeholder_proof_request_coverage_pct', 'quality_owner_assignment_coverage_pct'].includes(k)) {
+  if (['entity_delta_pct', 'chunk_ratio_delta', 'link_delta_pct', 'artifact_issues_count', 'quality_drift_signals_count', 'quality_narrative_coverage_pct', 'quality_dependency_coverage_pct', 'quality_decision_sequencing_coverage_pct', 'quality_close_scripts_coverage_pct', 'quality_failure_mode_rehearsal_coverage_pct', 'quality_stakeholder_proof_request_coverage_pct', 'quality_owner_assignment_coverage_pct', 'quality_counterfactual_decision_drill_coverage_pct', 'quality_stakeholder_objection_handoff_coverage_pct'].includes(k)) {
     return 'medium';
   }
   return 'low';
@@ -2782,7 +2889,7 @@ function buildTrendArtifactMarkdown(payload) {
   } else {
     lines.push(`- scanned_artifacts=${prep.scanned_artifacts ?? 0}, snapshots=${prep.snapshots ?? 0}, meetings_scored=${prep.meetings_scored ?? 0}`);
     lines.push(`- latest_avg_score=${formatNumber(prep.latest?.avg_score)}, latest_avg_gap_count=${formatNumber(prep.latest?.avg_gap_count)}, latest_severity_score=${formatNumber(prep.latest?.severity_score)}`);
-    lines.push(`- latest_readiness_score=${formatNumber(prep.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(prep.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(prep.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(prep.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(prep.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(prep.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(prep.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(prep.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(prep.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(prep.latest?.owner_assignment_coverage_pct)}`);
+    lines.push(`- latest_readiness_score=${formatNumber(prep.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(prep.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(prep.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(prep.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(prep.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(prep.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(prep.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(prep.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(prep.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(prep.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(prep.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(prep.latest?.stakeholder_objection_handoff_coverage_pct)}`);
     const driftSignals = Array.isArray(prep.drift_signals) ? prep.drift_signals : [];
     if (!driftSignals.length) {
       lines.push('- drift_signals=none');


### PR DESCRIPTION
## Summary
Implements data quality phase 14 from #163.

### What changed
- Extended `scripts/db/hybrid-ingestion-health.mjs` with phase-14 quality trendline support:
  - new snapshot metrics:
    - `counterfactual_decision_drill_coverage_pct`
    - `stakeholder_objection_handoff_coverage_pct`
  - new deterministic drift signals:
    - `counterfactual_decision_drill_coverage_drop`
    - `stakeholder_objection_handoff_coverage_drop`
  - new remediation lanes when latest coverage is below target:
    - `counterfactual_decision_drill_remediation`
    - `stakeholder_objection_handoff_remediation`
- Added new optional threshold guards and breach kinds:
  - `--min-quality-counterfactual-decision-drill-coverage-pct`
  - `--min-quality-stakeholder-objection-handoff-coverage-pct`
  - breach kinds:
    - `quality_counterfactual_decision_drill_coverage_pct`
    - `quality_stakeholder_objection_handoff_coverage_pct`
- Wired new fields through:
  - console threshold output + breach rendering
  - severity mapping
  - trend artifact markdown quality section
- Updated operator docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `node --check scripts/db/hybrid-ingestion-health.mjs`
- `npm run db:hybrid:init`
- `npm run db:hybrid:health`
- `npm run db:hybrid:health -- --json --max-quality-drift-signals 999 --max-quality-severity-score 999 --min-quality-counterfactual-decision-drill-coverage-pct 0 --min-quality-stakeholder-objection-handoff-coverage-pct 0`
- `npm run db:hybrid:health -- --json --min-quality-counterfactual-decision-drill-coverage-pct 101` (exit code `2` expected/confirmed)
- `npm run md:audit:strict`

Closes #163