### PR TITLE
feat(alerts): wire phase-14 quality breach routing and incident typing

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -217,6 +217,10 @@ jobs:
               quality_stakeholder_proof_request_breach_count: "0",
               quality_confidence_calibration_breach_count: "0",
               quality_owner_assignment_breach_count: "0",
+              quality_counterfactual_decision_drill_breach_count: "0",
+              quality_stakeholder_objection_handoff_breach_count: "0",
+              quality_phase14_top_breach_kind: "",
+              quality_phase14_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -255,9 +259,13 @@ jobs:
             const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
             const confidenceCalibrationBreachCount = breaches.filter((b) => b?.kind === "quality_confidence_calibration_drop").length;
             const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
+            const counterfactualDecisionDrillBreachCount = breaches.filter((b) => b?.kind === "quality_counterfactual_decision_drill_coverage_pct").length;
+            const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
+            const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
-            const qualityGateBreached = qualityPhase12GateBreached
+            const qualityGateBreached = qualityPhase14GateBreached
+              || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
             const qualityPhase12TopBreachKind =
@@ -268,6 +276,10 @@ jobs:
               confidenceCalibrationBreachCount >= ownerAssignmentBreachCount
                 ? (confidenceCalibrationBreachCount > 0 ? "quality_confidence_calibration_drop" : "")
                 : "quality_owner_assignment_coverage_pct";
+            const qualityPhase14TopBreachKind =
+              counterfactualDecisionDrillBreachCount >= stakeholderObjectionHandoffBreachCount
+                ? (counterfactualDecisionDrillBreachCount > 0 ? "quality_counterfactual_decision_drill_coverage_pct" : "")
+                : "quality_stakeholder_objection_handoff_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -276,6 +288,10 @@ jobs:
               quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
               quality_confidence_calibration_breach_count: String(confidenceCalibrationBreachCount),
               quality_owner_assignment_breach_count: String(ownerAssignmentBreachCount),
+              quality_counterfactual_decision_drill_breach_count: String(counterfactualDecisionDrillBreachCount),
+              quality_stakeholder_objection_handoff_breach_count: String(stakeholderObjectionHandoffBreachCount),
+              quality_phase14_top_breach_kind: qualityPhase14TopBreachKind,
+              quality_phase14_gate_breached: qualityPhase14GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -360,6 +376,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
           ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT: ${{ steps.quality.outputs.quality_confidence_calibration_breach_count }}
           ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT: ${{ steps.quality.outputs.quality_owner_assignment_breach_count }}
+          ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT: ${{ steps.quality.outputs.quality_counterfactual_decision_drill_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_objection_handoff_breach_count }}
+          ALERT_QUALITY_PHASE14_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase14_top_breach_kind }}
+          ALERT_QUALITY_PHASE14_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase14_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
@@ -608,6 +628,10 @@ jobs:
               quality_stakeholder_proof_request_breach_count: "0",
               quality_confidence_calibration_breach_count: "0",
               quality_owner_assignment_breach_count: "0",
+              quality_counterfactual_decision_drill_breach_count: "0",
+              quality_stakeholder_objection_handoff_breach_count: "0",
+              quality_phase14_top_breach_kind: "",
+              quality_phase14_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -646,9 +670,13 @@ jobs:
             const stakeholderProofRequestBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_proof_request_coverage_pct").length;
             const confidenceCalibrationBreachCount = breaches.filter((b) => b?.kind === "quality_confidence_calibration_drop").length;
             const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
+            const counterfactualDecisionDrillBreachCount = breaches.filter((b) => b?.kind === "quality_counterfactual_decision_drill_coverage_pct").length;
+            const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
+            const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
-            const qualityGateBreached = qualityPhase12GateBreached
+            const qualityGateBreached = qualityPhase14GateBreached
+              || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
             const qualityPhase12TopBreachKind =
@@ -659,6 +687,10 @@ jobs:
               confidenceCalibrationBreachCount >= ownerAssignmentBreachCount
                 ? (confidenceCalibrationBreachCount > 0 ? "quality_confidence_calibration_drop" : "")
                 : "quality_owner_assignment_coverage_pct";
+            const qualityPhase14TopBreachKind =
+              counterfactualDecisionDrillBreachCount >= stakeholderObjectionHandoffBreachCount
+                ? (counterfactualDecisionDrillBreachCount > 0 ? "quality_counterfactual_decision_drill_coverage_pct" : "")
+                : "quality_stakeholder_objection_handoff_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -667,6 +699,10 @@ jobs:
               quality_stakeholder_proof_request_breach_count: String(stakeholderProofRequestBreachCount),
               quality_confidence_calibration_breach_count: String(confidenceCalibrationBreachCount),
               quality_owner_assignment_breach_count: String(ownerAssignmentBreachCount),
+              quality_counterfactual_decision_drill_breach_count: String(counterfactualDecisionDrillBreachCount),
+              quality_stakeholder_objection_handoff_breach_count: String(stakeholderObjectionHandoffBreachCount),
+              quality_phase14_top_breach_kind: qualityPhase14TopBreachKind,
+              quality_phase14_gate_breached: qualityPhase14GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -847,6 +883,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_proof_request_breach_count }}
           ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT: ${{ steps.quality.outputs.quality_confidence_calibration_breach_count }}
           ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT: ${{ steps.quality.outputs.quality_owner_assignment_breach_count }}
+          ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT: ${{ steps.quality.outputs.quality_counterfactual_decision_drill_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_objection_handoff_breach_count }}
+          ALERT_QUALITY_PHASE14_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase14_top_breach_kind }}
+          ALERT_QUALITY_PHASE14_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase14_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}

--- a/db/README.md
+++ b/db/README.md
@@ -327,7 +327,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -400,6 +400,10 @@ Runtime notes:
       - `quality_drift_signal_count`
       - `quality_severity_score`
       - `quality_gate_breached`
+      - `quality_phase14_gate_breached`
+      - `quality_counterfactual_decision_drill_breach_count`
+      - `quality_stakeholder_objection_handoff_breach_count`
+      - `quality_phase14_top_breach_kind`
       - `quality_phase13_gate_breached`
       - `quality_confidence_calibration_breach_count`
       - `quality_owner_assignment_breach_count`

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -309,7 +309,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -367,6 +367,7 @@ Include:
       - deterministic ACK metadata (`ack_key`, `ack_marker`, `ack_sla_minutes`, `ack_due_at_utc`, `ack_due_at_et`, `ack_policy`, `ack_policy_applied`, `ack_policy_parse_error`)
       - deterministic incident-age metadata (`incident_age_minutes`, `incident_age_band`, `incident_age_warning_minutes`, `incident_age_critical_minutes`, `incident_age_escalation_due`, `incident_first_seen_at_utc`)
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
+      - phase-14 quality breach metadata (`quality_phase14_gate_breached`, `quality_counterfactual_decision_drill_breach_count`, `quality_stakeholder_objection_handoff_breach_count`, `quality_phase14_top_breach_kind`)
       - phase-13 quality breach metadata (`quality_phase13_gate_breached`, `quality_confidence_calibration_breach_count`, `quality_owner_assignment_breach_count`, `quality_phase13_top_breach_kind`)
       - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -197,9 +197,13 @@ function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualityPhase14GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED);
   const qualityPhase12GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED);
   const qualityPhase13GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED);
   const qualitySignalCount = Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "0");
+  const qualityPhase14BreachCount =
+    Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || "0");
   const qualityPhase12BreachCount =
     Number(process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "0");
@@ -208,6 +212,9 @@ function classifyIncident() {
     + Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase14GateBreached) {
+    return { type: "quality_phase14_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityPhase13GateBreached) {
     return { type: "quality_phase13_gate_breach", drift_related: false, quality_related: true, severity: "high" };
@@ -220,6 +227,9 @@ function classifyIncident() {
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase14BreachCount) && qualityPhase14BreachCount > 0) {
+    return { type: "quality_phase14_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualityPhase13BreachCount) && qualityPhase13BreachCount > 0) {
     return { type: "quality_phase13_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -273,7 +283,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
-  } else if (incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
+  } else if (incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
@@ -285,7 +295,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
-  } else if (incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
+  } else if (incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
     defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
@@ -740,6 +750,10 @@ function buildAlertText({
   const qualityConfidenceCalibrationBreachCount = process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || "";
   const qualityOwnerAssignmentBreachCount = process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "";
   const qualityPhase13TopBreachKind = process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || "";
+  const qualityPhase14GateBreached = process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED || "";
+  const qualityCounterfactualDecisionDrillBreachCount = process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || "";
+  const qualityStakeholderObjectionHandoffBreachCount = process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || "";
+  const qualityPhase14TopBreachKind = process.env.ALERT_QUALITY_PHASE14_TOP_BREACH_KIND || "";
   const qualityPhase12GateBreached = process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED || "";
   const qualityFailureModeRehearsalBreachCount = process.env.ALERT_QUALITY_FAILURE_MODE_REHEARSAL_BREACH_COUNT || "";
   const qualityStakeholderProofRequestBreachCount = process.env.ALERT_QUALITY_STAKEHOLDER_PROOF_REQUEST_BREACH_COUNT || "";
@@ -793,6 +807,10 @@ function buildAlertText({
     qualitySeverityScore ||
     qualityGateBreached ||
     qualityPhase13GateBreached ||
+    qualityPhase14GateBreached ||
+    qualityCounterfactualDecisionDrillBreachCount ||
+    qualityStakeholderObjectionHandoffBreachCount ||
+    qualityPhase14TopBreachKind ||
     qualityConfidenceCalibrationBreachCount ||
     qualityOwnerAssignmentBreachCount ||
     qualityPhase13TopBreachKind ||
@@ -806,6 +824,9 @@ function buildAlertText({
   ) {
     lines.push(
       `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
+    lines.push(
+      `Meeting-prep quality phase14: gateBreached=${qualityPhase14GateBreached || "n/a"}, counterfactualDecisionDrillBreaches=${qualityCounterfactualDecisionDrillBreachCount || "0"}, stakeholderObjectionHandoffBreaches=${qualityStakeholderObjectionHandoffBreachCount || "0"}, phase14TopBreachKind=${qualityPhase14TopBreachKind || "n/a"}`
     );
     lines.push(
       `Meeting-prep quality phase13: gateBreached=${qualityPhase13GateBreached || "n/a"}, confidenceCalibrationBreaches=${qualityConfidenceCalibrationBreachCount || "0"}, ownerAssignmentBreaches=${qualityOwnerAssignmentBreachCount || "0"}, phase13TopBreachKind=${qualityPhase13TopBreachKind || "n/a"}`
@@ -1116,8 +1137,12 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
       quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
       quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_counterfactual_decision_drill_breach_count: Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || 0),
+      quality_stakeholder_objection_handoff_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || 0),
+      quality_phase14_top_breach_kind: process.env.ALERT_QUALITY_PHASE14_TOP_BREACH_KIND || null,
       quality_confidence_calibration_breach_count: Number(process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || 0),
       quality_owner_assignment_breach_count: Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || 0),
       quality_phase13_top_breach_kind: process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || null,
@@ -1181,8 +1206,12 @@ async function main() {
     quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
     quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
     quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
     quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
     quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_counterfactual_decision_drill_breach_count: Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || 0),
+    quality_stakeholder_objection_handoff_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || 0),
+    quality_phase14_top_breach_kind: process.env.ALERT_QUALITY_PHASE14_TOP_BREACH_KIND || null,
     quality_confidence_calibration_breach_count: Number(process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || 0),
     quality_owner_assignment_breach_count: Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || 0),
     quality_phase13_top_breach_kind: process.env.ALERT_QUALITY_PHASE13_TOP_BREACH_KIND || null,


### PR DESCRIPTION
## Summary
Implements live ops phase 14 from #166.

### What changed
- Updated quality extraction in `.github/workflows/hybrid-daily-pipeline.yml` (both canary and live lanes) to emit phase-14 metadata from health breaches:
  - `quality_counterfactual_decision_drill_breach_count`
  - `quality_stakeholder_objection_handoff_breach_count`
  - `quality_phase14_top_breach_kind`
  - `quality_phase14_gate_breached`
- Wired new phase-14 outputs into dispatcher env for both lanes:
  - `ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT`
  - `ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT`
  - `ALERT_QUALITY_PHASE14_TOP_BREACH_KIND`
  - `ALERT_QUALITY_PHASE14_GATE_BREACHED`
- Extended `scripts/ci/dispatch-hybrid-alert.mjs`:
  - new incident classes:
    - `quality_phase14_gate_breach`
    - `quality_phase14_signal_detected`
  - ACK policy defaults now treat phase-14 incidents as high-priority quality incidents (same strict SLA profile as phase-12/13 gate breaches)
  - phase-14 metadata included in alert text, payload metadata, and dispatch summary contracts
- Updated docs:
  - `db/README.md`
  - `docs/RUNBOOK_DEPLOY_GENERIC.md`

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- workflow YAML parse check
- dispatcher dry-run with phase-14 gate env vars:
  - confirmed `incident_type=quality_phase14_gate_breach`
  - confirmed phase-14 metadata fields in summary output
- `npm run md:audit:strict`

Closes #166