### PR TITLE
feat: live ops phase 15 quality gate routing and policy wiring

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -221,6 +221,10 @@ jobs:
               quality_stakeholder_objection_handoff_breach_count: "0",
               quality_phase14_top_breach_kind: "",
               quality_phase14_gate_breached: "false",
+              quality_risk_weighted_close_plan_sequencing_breach_count: "0",
+              quality_cross_owner_dependency_signoff_breach_count: "0",
+              quality_phase15_top_breach_kind: "",
+              quality_phase15_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -261,10 +265,14 @@ jobs:
             const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
             const counterfactualDecisionDrillBreachCount = breaches.filter((b) => b?.kind === "quality_counterfactual_decision_drill_coverage_pct").length;
             const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
+            const riskWeightedClosePlanSequencingBreachCount = breaches.filter((b) => b?.kind === "quality_risk_weighted_close_plan_sequencing_coverage_pct").length;
+            const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
+            const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
+              || qualityPhase15GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -280,6 +288,10 @@ jobs:
               counterfactualDecisionDrillBreachCount >= stakeholderObjectionHandoffBreachCount
                 ? (counterfactualDecisionDrillBreachCount > 0 ? "quality_counterfactual_decision_drill_coverage_pct" : "")
                 : "quality_stakeholder_objection_handoff_coverage_pct";
+            const qualityPhase15TopBreachKind =
+              riskWeightedClosePlanSequencingBreachCount >= crossOwnerDependencySignoffBreachCount
+                ? (riskWeightedClosePlanSequencingBreachCount > 0 ? "quality_risk_weighted_close_plan_sequencing_coverage_pct" : "")
+                : "quality_cross_owner_dependency_signoff_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -292,6 +304,10 @@ jobs:
               quality_stakeholder_objection_handoff_breach_count: String(stakeholderObjectionHandoffBreachCount),
               quality_phase14_top_breach_kind: qualityPhase14TopBreachKind,
               quality_phase14_gate_breached: qualityPhase14GateBreached ? "true" : "false",
+              quality_risk_weighted_close_plan_sequencing_breach_count: String(riskWeightedClosePlanSequencingBreachCount),
+              quality_cross_owner_dependency_signoff_breach_count: String(crossOwnerDependencySignoffBreachCount),
+              quality_phase15_top_breach_kind: qualityPhase15TopBreachKind,
+              quality_phase15_gate_breached: qualityPhase15GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -380,6 +396,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_objection_handoff_breach_count }}
           ALERT_QUALITY_PHASE14_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase14_top_breach_kind }}
           ALERT_QUALITY_PHASE14_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase14_gate_breached }}
+          ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT: ${{ steps.quality.outputs.quality_risk_weighted_close_plan_sequencing_breach_count }}
+          ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_cross_owner_dependency_signoff_breach_count }}
+          ALERT_QUALITY_PHASE15_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase15_top_breach_kind }}
+          ALERT_QUALITY_PHASE15_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase15_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
@@ -632,6 +652,10 @@ jobs:
               quality_stakeholder_objection_handoff_breach_count: "0",
               quality_phase14_top_breach_kind: "",
               quality_phase14_gate_breached: "false",
+              quality_risk_weighted_close_plan_sequencing_breach_count: "0",
+              quality_cross_owner_dependency_signoff_breach_count: "0",
+              quality_phase15_top_breach_kind: "",
+              quality_phase15_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -672,10 +696,14 @@ jobs:
             const ownerAssignmentBreachCount = breaches.filter((b) => b?.kind === "quality_owner_assignment_coverage_pct").length;
             const counterfactualDecisionDrillBreachCount = breaches.filter((b) => b?.kind === "quality_counterfactual_decision_drill_coverage_pct").length;
             const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
+            const riskWeightedClosePlanSequencingBreachCount = breaches.filter((b) => b?.kind === "quality_risk_weighted_close_plan_sequencing_coverage_pct").length;
+            const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
+            const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
+              || qualityPhase15GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -691,6 +719,10 @@ jobs:
               counterfactualDecisionDrillBreachCount >= stakeholderObjectionHandoffBreachCount
                 ? (counterfactualDecisionDrillBreachCount > 0 ? "quality_counterfactual_decision_drill_coverage_pct" : "")
                 : "quality_stakeholder_objection_handoff_coverage_pct";
+            const qualityPhase15TopBreachKind =
+              riskWeightedClosePlanSequencingBreachCount >= crossOwnerDependencySignoffBreachCount
+                ? (riskWeightedClosePlanSequencingBreachCount > 0 ? "quality_risk_weighted_close_plan_sequencing_coverage_pct" : "")
+                : "quality_cross_owner_dependency_signoff_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -703,6 +735,10 @@ jobs:
               quality_stakeholder_objection_handoff_breach_count: String(stakeholderObjectionHandoffBreachCount),
               quality_phase14_top_breach_kind: qualityPhase14TopBreachKind,
               quality_phase14_gate_breached: qualityPhase14GateBreached ? "true" : "false",
+              quality_risk_weighted_close_plan_sequencing_breach_count: String(riskWeightedClosePlanSequencingBreachCount),
+              quality_cross_owner_dependency_signoff_breach_count: String(crossOwnerDependencySignoffBreachCount),
+              quality_phase15_top_breach_kind: qualityPhase15TopBreachKind,
+              quality_phase15_gate_breached: qualityPhase15GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -887,6 +923,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_objection_handoff_breach_count }}
           ALERT_QUALITY_PHASE14_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase14_top_breach_kind }}
           ALERT_QUALITY_PHASE14_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase14_gate_breached }}
+          ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT: ${{ steps.quality.outputs.quality_risk_weighted_close_plan_sequencing_breach_count }}
+          ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_cross_owner_dependency_signoff_breach_count }}
+          ALERT_QUALITY_PHASE15_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase15_top_breach_kind }}
+          ALERT_QUALITY_PHASE15_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase15_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}

--- a/db/README.md
+++ b/db/README.md
@@ -331,7 +331,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -408,6 +408,10 @@ Runtime notes:
       - `quality_counterfactual_decision_drill_breach_count`
       - `quality_stakeholder_objection_handoff_breach_count`
       - `quality_phase14_top_breach_kind`
+      - `quality_phase15_gate_breached`
+      - `quality_risk_weighted_close_plan_sequencing_breach_count`
+      - `quality_cross_owner_dependency_signoff_breach_count`
+      - `quality_phase15_top_breach_kind`
       - `quality_phase13_gate_breached`
       - `quality_confidence_calibration_breach_count`
       - `quality_owner_assignment_breach_count`

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -311,7 +311,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -370,6 +370,7 @@ Include:
       - deterministic incident-age metadata (`incident_age_minutes`, `incident_age_band`, `incident_age_warning_minutes`, `incident_age_critical_minutes`, `incident_age_escalation_due`, `incident_first_seen_at_utc`)
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
       - phase-14 quality breach metadata (`quality_phase14_gate_breached`, `quality_counterfactual_decision_drill_breach_count`, `quality_stakeholder_objection_handoff_breach_count`, `quality_phase14_top_breach_kind`)
+      - phase-15 quality breach metadata (`quality_phase15_gate_breached`, `quality_risk_weighted_close_plan_sequencing_breach_count`, `quality_cross_owner_dependency_signoff_breach_count`, `quality_phase15_top_breach_kind`)
       - phase-13 quality breach metadata (`quality_phase13_gate_breached`, `quality_confidence_calibration_breach_count`, `quality_owner_assignment_breach_count`, `quality_phase13_top_breach_kind`)
       - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -197,10 +197,14 @@ function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualityPhase15GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED);
   const qualityPhase14GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED);
   const qualityPhase12GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED);
   const qualityPhase13GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED);
   const qualitySignalCount = Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "0");
+  const qualityPhase15BreachCount =
+    Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || "0");
   const qualityPhase14BreachCount =
     Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || "0");
@@ -212,6 +216,9 @@ function classifyIncident() {
     + Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase15GateBreached) {
+    return { type: "quality_phase15_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityPhase14GateBreached) {
     return { type: "quality_phase14_gate_breach", drift_related: false, quality_related: true, severity: "high" };
@@ -227,6 +234,9 @@ function classifyIncident() {
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase15BreachCount) && qualityPhase15BreachCount > 0) {
+    return { type: "quality_phase15_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualityPhase14BreachCount) && qualityPhase14BreachCount > 0) {
     return { type: "quality_phase14_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -283,7 +293,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
-  } else if (incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
+  } else if (incident.type === "quality_phase15_gate_breach" || incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
@@ -295,7 +305,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
-  } else if (incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
+  } else if (incident.type === "quality_phase15_signal_detected" || incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
     defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
@@ -746,6 +756,10 @@ function buildAlertText({
   const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
   const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
   const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityPhase15GateBreached = process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED || "";
+  const qualityRiskWeightedClosePlanSequencingBreachCount = process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || "";
+  const qualityCrossOwnerDependencySignoffBreachCount = process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || "";
+  const qualityPhase15TopBreachKind = process.env.ALERT_QUALITY_PHASE15_TOP_BREACH_KIND || "";
   const qualityPhase13GateBreached = process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED || "";
   const qualityConfidenceCalibrationBreachCount = process.env.ALERT_QUALITY_CONFIDENCE_CALIBRATION_BREACH_COUNT || "";
   const qualityOwnerAssignmentBreachCount = process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "";
@@ -806,6 +820,10 @@ function buildAlertText({
     qualitySignals ||
     qualitySeverityScore ||
     qualityGateBreached ||
+    qualityPhase15GateBreached ||
+    qualityRiskWeightedClosePlanSequencingBreachCount ||
+    qualityCrossOwnerDependencySignoffBreachCount ||
+    qualityPhase15TopBreachKind ||
     qualityPhase13GateBreached ||
     qualityPhase14GateBreached ||
     qualityCounterfactualDecisionDrillBreachCount ||
@@ -824,6 +842,9 @@ function buildAlertText({
   ) {
     lines.push(
       `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
+    lines.push(
+      `Meeting-prep quality phase15: gateBreached=${qualityPhase15GateBreached || "n/a"}, riskWeightedClosePlanSequencingBreaches=${qualityRiskWeightedClosePlanSequencingBreachCount || "0"}, crossOwnerDependencySignoffBreaches=${qualityCrossOwnerDependencySignoffBreachCount || "0"}, phase15TopBreachKind=${qualityPhase15TopBreachKind || "n/a"}`
     );
     lines.push(
       `Meeting-prep quality phase14: gateBreached=${qualityPhase14GateBreached || "n/a"}, counterfactualDecisionDrillBreaches=${qualityCounterfactualDecisionDrillBreachCount || "0"}, stakeholderObjectionHandoffBreaches=${qualityStakeholderObjectionHandoffBreachCount || "0"}, phase14TopBreachKind=${qualityPhase14TopBreachKind || "n/a"}`
@@ -1137,9 +1158,13 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
       quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
       quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
       quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_risk_weighted_close_plan_sequencing_breach_count: Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || 0),
+      quality_cross_owner_dependency_signoff_breach_count: Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || 0),
+      quality_phase15_top_breach_kind: process.env.ALERT_QUALITY_PHASE15_TOP_BREACH_KIND || null,
       quality_counterfactual_decision_drill_breach_count: Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || 0),
       quality_stakeholder_objection_handoff_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || 0),
       quality_phase14_top_breach_kind: process.env.ALERT_QUALITY_PHASE14_TOP_BREACH_KIND || null,
@@ -1206,9 +1231,13 @@ async function main() {
     quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
     quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
     quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
     quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
     quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
     quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_risk_weighted_close_plan_sequencing_breach_count: Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || 0),
+    quality_cross_owner_dependency_signoff_breach_count: Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || 0),
+    quality_phase15_top_breach_kind: process.env.ALERT_QUALITY_PHASE15_TOP_BREACH_KIND || null,
     quality_counterfactual_decision_drill_breach_count: Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || 0),
     quality_stakeholder_objection_handoff_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || 0),
     quality_phase14_top_breach_kind: process.env.ALERT_QUALITY_PHASE14_TOP_BREACH_KIND || null,


### PR DESCRIPTION
## Summary
- execute queue default from #174 via #175 (live ops phase 15)
- extend workflow quality metadata extraction (canary + live lanes) with phase-15 outputs:
  - `quality_risk_weighted_close_plan_sequencing_breach_count`
  - `quality_cross_owner_dependency_signoff_breach_count`
  - `quality_phase15_top_breach_kind`
  - `quality_phase15_gate_breached`
- include phase-15 in aggregate quality gate evaluation and top-breach routing logic
- extend alert dispatch env wiring with phase-15 metadata fields
- extend `scripts/ci/dispatch-hybrid-alert.mjs`:
  - incident classification: `quality_phase15_gate_breach`, `quality_phase15_signal_detected`
  - deterministic ACK policy handling for phase-15 gate/signal incidents
  - alert text + metadata payload + summary payload phase-15 fields
- update docs (`db/README.md`, `docs/RUNBOOK_DEPLOY_GENERIC.md`) for new incident types and phase-15 alert metadata

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/hybrid-daily-pipeline.yml")'`
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- `ALERT_DRY_RUN=1 ALERT_WEBHOOK_URL=https://example.com ALERT_QUALITY_GATE_BREACHED=true ALERT_QUALITY_PHASE15_GATE_BREACHED=true ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT=2 ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT=1 ALERT_QUALITY_PHASE15_TOP_BREACH_KIND=quality_risk_weighted_close_plan_sequencing_coverage_pct node scripts/ci/dispatch-hybrid-alert.mjs`
  - confirms `incident_type=quality_phase15_gate_breach` and phase-15 metadata in output
- `npm run md:audit:strict`

## Context
- Closes #175