### PR TITLE
feat(health): add phase-16 close-readiness/signoff drift gates

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -296,6 +296,8 @@ Runtime notes:
       - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
       - `--min-quality-risk-weighted-close-plan-sequencing-coverage-pct <n>`
       - `--min-quality-cross-owner-dependency-signoff-coverage-pct <n>`
+      - `--min-quality-close-readiness-gate-matrix-coverage-pct <n>`
+      - `--min-quality-stakeholder-signoff-escalation-ladder-coverage-pct <n>`
 - Threshold breaches return exit code `2`, causing the workflow job to fail while still uploading artifacts via `if: always()`.
 - Live lane also runs canary-vs-live drift comparison after health report generation:
   - resolves latest same-date canary artifact (`hybrid-daily-canary-YYYY-MM-DD`) via GitHub Actions artifact API
@@ -557,6 +559,8 @@ Optional flags:
   - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
   - `--min-quality-risk-weighted-close-plan-sequencing-coverage-pct <n>`
   - `--min-quality-cross-owner-dependency-signoff-coverage-pct <n>`
+  - `--min-quality-close-readiness-gate-matrix-coverage-pct <n>`
+  - `--min-quality-stakeholder-signoff-escalation-ladder-coverage-pct <n>`
 
 Threshold-gated example (CI/alerts):
 ```bash
@@ -596,7 +600,9 @@ npm run db:hybrid:health -- \
   --min-quality-counterfactual-decision-drill-coverage-pct 0 \
   --min-quality-stakeholder-objection-handoff-coverage-pct 0 \
   --min-quality-risk-weighted-close-plan-sequencing-coverage-pct 0 \
-  --min-quality-cross-owner-dependency-signoff-coverage-pct 0
+  --min-quality-cross-owner-dependency-signoff-coverage-pct 0 \
+  --min-quality-close-readiness-gate-matrix-coverage-pct 0 \
+  --min-quality-stakeholder-signoff-escalation-ladder-coverage-pct 0
 ```
 
 Exit behavior:
@@ -637,8 +643,8 @@ Output includes:
   - aggregates breach events by severity and source/top breach kinds
 - threshold metadata (`thresholds`) and explicit breach records (`breaches`)
 - meeting-prep quality trendline drift analysis from `artifacts/meeting-prep-quality-*.json` and `artifacts/meeting-prep-phase*.json`:
-  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`)
-  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`, `counterfactual_decision_drill_coverage_drop`, `stakeholder_objection_handoff_coverage_drop`, `risk_weighted_close_plan_sequencing_coverage_drop`, `cross_owner_dependency_signoff_coverage_drop`)
+  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`)
+  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`, `counterfactual_decision_drill_coverage_drop`, `stakeholder_objection_handoff_coverage_drop`, `risk_weighted_close_plan_sequencing_coverage_drop`, `cross_owner_dependency_signoff_coverage_drop`, `close_readiness_gate_matrix_coverage_drop`, `stakeholder_signoff_escalation_ladder_coverage_drop`)
   - deterministic escalation lanes by latest gap severity (`immediate_owner_escalation`, `same_day_quality_remediation`, `next_cycle_hardening`, `monitor_only`)
 - trend artifact export metadata (`trend_artifacts`) with written/pruned file paths when enabled
 - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned file paths when enabled

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -476,6 +476,8 @@ Include:
     - `--min-quality-stakeholder-objection-handoff-coverage-pct <n>`
     - `--min-quality-risk-weighted-close-plan-sequencing-coverage-pct <n>`
     - `--min-quality-cross-owner-dependency-signoff-coverage-pct <n>`
+    - `--min-quality-close-readiness-gate-matrix-coverage-pct <n>`
+    - `--min-quality-stakeholder-signoff-escalation-ladder-coverage-pct <n>`
 - Report fields include:
   - source cursor lag/drift for `gmail`, `google_calendar`, and `kb_ingest`
   - entity/chunk coverage totals and grouped `domain/type` counts
@@ -509,7 +511,7 @@ Include:
   - meeting-prep quality trendline drift analysis:
     - scans `meeting-prep-quality-*.json` + `meeting-prep-phase*.json`
     - emits deterministic drift signals and severity-based escalation lanes
-    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`)
+    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`)
   - trend artifact export metadata (`trend_artifacts`) with written/pruned files when export is enabled
   - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned files when export is enabled
 
@@ -551,7 +553,9 @@ npm run db:hybrid:health -- \
   --min-quality-counterfactual-decision-drill-coverage-pct 0 \
   --min-quality-stakeholder-objection-handoff-coverage-pct 0 \
   --min-quality-risk-weighted-close-plan-sequencing-coverage-pct 0 \
-  --min-quality-cross-owner-dependency-signoff-coverage-pct 0
+  --min-quality-cross-owner-dependency-signoff-coverage-pct 0 \
+  --min-quality-close-readiness-gate-matrix-coverage-pct 0 \
+  --min-quality-stakeholder-signoff-escalation-ladder-coverage-pct 0
 ```
 
 Exit behavior:

--- a/scripts/db/hybrid-ingestion-health.mjs
+++ b/scripts/db/hybrid-ingestion-health.mjs
@@ -66,6 +66,8 @@ const thresholds = {
   min_quality_stakeholder_objection_handoff_coverage_pct: readOptionalNumberArg(args, '--min-quality-stakeholder-objection-handoff-coverage-pct'),
   min_quality_risk_weighted_close_plan_sequencing_coverage_pct: readOptionalNumberArg(args, '--min-quality-risk-weighted-close-plan-sequencing-coverage-pct'),
   min_quality_cross_owner_dependency_signoff_coverage_pct: readOptionalNumberArg(args, '--min-quality-cross-owner-dependency-signoff-coverage-pct'),
+  min_quality_close_readiness_gate_matrix_coverage_pct: readOptionalNumberArg(args, '--min-quality-close-readiness-gate-matrix-coverage-pct'),
+  min_quality_stakeholder_signoff_escalation_ladder_coverage_pct: readOptionalNumberArg(args, '--min-quality-stakeholder-signoff-escalation-ladder-coverage-pct'),
 };
 const hasThresholds = Object.values(thresholds).some((value) => value !== null);
 
@@ -477,9 +479,9 @@ function printMarkdown(result, artifactDirInput) {
   } else {
     console.log(`- scanned_artifacts=${result.meeting_prep_quality.scanned_artifacts}, snapshots=${result.meeting_prep_quality.snapshots}, meetings_scored=${result.meeting_prep_quality.meetings_scored}`);
     console.log(`- latest_avg_score=${formatNumber(result.meeting_prep_quality.latest?.avg_score)}, latest_avg_gap_count=${formatNumber(result.meeting_prep_quality.latest?.avg_gap_count)}, latest_severity_score=${formatNumber(result.meeting_prep_quality.latest?.severity_score)}`);
-    console.log(`- latest_readiness_score=${formatNumber(result.meeting_prep_quality.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_objection_handoff_coverage_pct)}, latest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.risk_weighted_close_plan_sequencing_coverage_pct)}, latest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.cross_owner_dependency_signoff_coverage_pct)}`);
+    console.log(`- latest_readiness_score=${formatNumber(result.meeting_prep_quality.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_objection_handoff_coverage_pct)}, latest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.risk_weighted_close_plan_sequencing_coverage_pct)}, latest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.cross_owner_dependency_signoff_coverage_pct)}, latest_close_readiness_gate_matrix_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.close_readiness_gate_matrix_coverage_pct)}, latest_stakeholder_signoff_escalation_ladder_coverage_pct=${formatNumber(result.meeting_prep_quality.latest?.stakeholder_signoff_escalation_ladder_coverage_pct)}`);
     console.log(`- oldest_avg_score=${formatNumber(result.meeting_prep_quality.oldest?.avg_score)}, oldest_avg_gap_count=${formatNumber(result.meeting_prep_quality.oldest?.avg_gap_count)}, oldest_severity_score=${formatNumber(result.meeting_prep_quality.oldest?.severity_score)}`);
-    console.log(`- oldest_readiness_score=${formatNumber(result.meeting_prep_quality.oldest?.readiness_score)}, oldest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.narrative_coverage_pct)}, oldest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.dependency_coverage_pct)}, oldest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.decision_sequencing_coverage_pct)}, oldest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.close_scripts_coverage_pct)}, oldest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.failure_mode_rehearsal_coverage_pct)}, oldest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_proof_request_coverage_pct)}, oldest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_coverage_pct)}, oldest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_avg_delta)}, oldest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.owner_assignment_coverage_pct)}, oldest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.counterfactual_decision_drill_coverage_pct)}, oldest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_objection_handoff_coverage_pct)}, oldest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.risk_weighted_close_plan_sequencing_coverage_pct)}, oldest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.cross_owner_dependency_signoff_coverage_pct)}`);
+    console.log(`- oldest_readiness_score=${formatNumber(result.meeting_prep_quality.oldest?.readiness_score)}, oldest_narrative_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.narrative_coverage_pct)}, oldest_dependency_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.dependency_coverage_pct)}, oldest_decision_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.decision_sequencing_coverage_pct)}, oldest_close_scripts_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.close_scripts_coverage_pct)}, oldest_failure_mode_rehearsal_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.failure_mode_rehearsal_coverage_pct)}, oldest_stakeholder_proof_request_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_proof_request_coverage_pct)}, oldest_confidence_calibration_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_coverage_pct)}, oldest_confidence_calibration_avg_delta=${formatNumber(result.meeting_prep_quality.oldest?.confidence_calibration_avg_delta)}, oldest_owner_assignment_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.owner_assignment_coverage_pct)}, oldest_counterfactual_decision_drill_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.counterfactual_decision_drill_coverage_pct)}, oldest_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_objection_handoff_coverage_pct)}, oldest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.risk_weighted_close_plan_sequencing_coverage_pct)}, oldest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.cross_owner_dependency_signoff_coverage_pct)}, oldest_close_readiness_gate_matrix_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.close_readiness_gate_matrix_coverage_pct)}, oldest_stakeholder_signoff_escalation_ladder_coverage_pct=${formatNumber(result.meeting_prep_quality.oldest?.stakeholder_signoff_escalation_ladder_coverage_pct)}`);
 
     const driftSignals = Array.isArray(result.meeting_prep_quality.drift_signals) ? result.meeting_prep_quality.drift_signals : [];
     if (!driftSignals.length) {
@@ -607,6 +609,8 @@ function printMarkdown(result, artifactDirInput) {
   console.log(`- min_quality_stakeholder_objection_handoff_coverage_pct=${formatNumber(result.thresholds.min_quality_stakeholder_objection_handoff_coverage_pct)}`);
   console.log(`- min_quality_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(result.thresholds.min_quality_risk_weighted_close_plan_sequencing_coverage_pct)}`);
   console.log(`- min_quality_cross_owner_dependency_signoff_coverage_pct=${formatNumber(result.thresholds.min_quality_cross_owner_dependency_signoff_coverage_pct)}`);
+  console.log(`- min_quality_close_readiness_gate_matrix_coverage_pct=${formatNumber(result.thresholds.min_quality_close_readiness_gate_matrix_coverage_pct)}`);
+  console.log(`- min_quality_stakeholder_signoff_escalation_ladder_coverage_pct=${formatNumber(result.thresholds.min_quality_stakeholder_signoff_escalation_ladder_coverage_pct)}`);
   console.log(`- breaches=${result.breaches.length}`);
 
   if (!result.breaches.length) {
@@ -697,6 +701,14 @@ function printMarkdown(result, artifactDirInput) {
     }
     if (breach.kind === 'quality_cross_owner_dependency_signoff_coverage_pct') {
       console.log(`- [breach] quality cross-owner dependency signoff coverage: actual=${breach.actual} < minimum=${breach.limit}`);
+      continue;
+    }
+    if (breach.kind === 'quality_close_readiness_gate_matrix_coverage_pct') {
+      console.log(`- [breach] quality close-readiness gate matrix coverage: actual=${breach.actual} < minimum=${breach.limit}`);
+      continue;
+    }
+    if (breach.kind === 'quality_stakeholder_signoff_escalation_ladder_coverage_pct') {
+      console.log(`- [breach] quality stakeholder signoff escalation-ladder coverage: actual=${breach.actual} < minimum=${breach.limit}`);
       continue;
     }
     console.log(`- [breach] ${breach.source} ${breach.kind}: actual=${breach.actual} > limit=${breach.limit}`);
@@ -1428,6 +1440,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
     let stakeholderObjectionHandoffCovered = 0;
     let riskWeightedClosePlanSequencingCovered = 0;
     let crossOwnerDependencySignoffCovered = 0;
+    let closeReadinessGateMatrixCovered = 0;
+    let stakeholderSignoffEscalationLadderCovered = 0;
     const confidenceCalibrationDeltas = [];
     const ownerAssignmentCoveragePcts = [];
     const readinessScores = [];
@@ -1447,6 +1461,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       const stakeholderObjectionHandoffComplete = hasStakeholderObjectionResponseHandoffMap(meeting?.stakeholderObjectionResponseHandoffMap);
       const riskWeightedClosePlanSequencingComplete = hasRiskWeightedClosePlanSequencing(meeting?.riskWeightedClosePlanSequencing);
       const crossOwnerDependencySignoffComplete = hasCrossOwnerDependencySignoffPack(meeting?.crossOwnerDependencySignoffPack);
+      const closeReadinessGateMatrixComplete = hasCloseReadinessGateMatrix(meeting?.closeReadinessGateMatrix);
+      const stakeholderSignoffEscalationLadderComplete = hasStakeholderSignoffEscalationLadder(meeting?.stakeholderSignoffEscalationLadder);
       const ownerAssignmentCoveragePct = computeOwnerAssignmentCoveragePct({
         balancing: meeting?.actionOwnerLoadBalancing,
         meetingRecommendations: meeting?.meetingRecommendations,
@@ -1462,6 +1478,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       if (stakeholderObjectionHandoffComplete) stakeholderObjectionHandoffCovered += 1;
       if (riskWeightedClosePlanSequencingComplete) riskWeightedClosePlanSequencingCovered += 1;
       if (crossOwnerDependencySignoffComplete) crossOwnerDependencySignoffCovered += 1;
+      if (closeReadinessGateMatrixComplete) closeReadinessGateMatrixCovered += 1;
+      if (stakeholderSignoffEscalationLadderComplete) stakeholderSignoffEscalationLadderCovered += 1;
       if (confidenceCalibrationComplete) {
         confidenceCalibrationCovered += 1;
         confidenceCalibrationDeltas.push(Number(meeting?.confidenceCalibrationTrend?.averageDelta || 0));
@@ -1490,6 +1508,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
     const stakeholderObjectionHandoffCoveragePct = Number(((stakeholderObjectionHandoffCovered / scored.length) * 100).toFixed(3));
     const riskWeightedClosePlanSequencingCoveragePct = Number(((riskWeightedClosePlanSequencingCovered / scored.length) * 100).toFixed(3));
     const crossOwnerDependencySignoffCoveragePct = Number(((crossOwnerDependencySignoffCovered / scored.length) * 100).toFixed(3));
+    const closeReadinessGateMatrixCoveragePct = Number(((closeReadinessGateMatrixCovered / scored.length) * 100).toFixed(3));
+    const stakeholderSignoffEscalationLadderCoveragePct = Number(((stakeholderSignoffEscalationLadderCovered / scored.length) * 100).toFixed(3));
     const confidenceCalibrationAvgDelta = confidenceCalibrationDeltas.length
       ? Number((confidenceCalibrationDeltas.reduce((sum, value) => sum + value, 0) / confidenceCalibrationDeltas.length).toFixed(3))
       : null;
@@ -1528,6 +1548,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       stakeholder_objection_handoff_coverage_pct: stakeholderObjectionHandoffCoveragePct,
       risk_weighted_close_plan_sequencing_coverage_pct: riskWeightedClosePlanSequencingCoveragePct,
       cross_owner_dependency_signoff_coverage_pct: crossOwnerDependencySignoffCoveragePct,
+      close_readiness_gate_matrix_coverage_pct: closeReadinessGateMatrixCoveragePct,
+      stakeholder_signoff_escalation_ladder_coverage_pct: stakeholderSignoffEscalationLadderCoveragePct,
       narrative_covered_count: narrativeCovered,
       dependency_covered_count: dependencyCovered,
       sequencing_covered_count: sequencingCovered,
@@ -1539,6 +1561,8 @@ function readMeetingPrepQualityTrends({ artifactDirInput }) {
       stakeholder_objection_handoff_covered_count: stakeholderObjectionHandoffCovered,
       risk_weighted_close_plan_sequencing_covered_count: riskWeightedClosePlanSequencingCovered,
       cross_owner_dependency_signoff_covered_count: crossOwnerDependencySignoffCovered,
+      close_readiness_gate_matrix_covered_count: closeReadinessGateMatrixCovered,
+      stakeholder_signoff_escalation_ladder_covered_count: stakeholderSignoffEscalationLadderCovered,
       severity_score: severityScore,
       levels: levelCounts,
       failing_check_severity: severityCounts,
@@ -1597,6 +1621,8 @@ function buildMeetingPrepQualityDriftSignals({ oldest, latest }) {
   const stakeholderObjectionHandoffCoverageDelta = Number((Number(latest.stakeholder_objection_handoff_coverage_pct || 0) - Number(oldest.stakeholder_objection_handoff_coverage_pct || 0)).toFixed(3));
   const riskWeightedClosePlanSequencingCoverageDelta = Number((Number(latest.risk_weighted_close_plan_sequencing_coverage_pct || 0) - Number(oldest.risk_weighted_close_plan_sequencing_coverage_pct || 0)).toFixed(3));
   const crossOwnerDependencySignoffCoverageDelta = Number((Number(latest.cross_owner_dependency_signoff_coverage_pct || 0) - Number(oldest.cross_owner_dependency_signoff_coverage_pct || 0)).toFixed(3));
+  const closeReadinessGateMatrixCoverageDelta = Number((Number(latest.close_readiness_gate_matrix_coverage_pct || 0) - Number(oldest.close_readiness_gate_matrix_coverage_pct || 0)).toFixed(3));
+  const stakeholderSignoffEscalationLadderCoverageDelta = Number((Number(latest.stakeholder_signoff_escalation_ladder_coverage_pct || 0) - Number(oldest.stakeholder_signoff_escalation_ladder_coverage_pct || 0)).toFixed(3));
   const severityDelta = Number((Number(latest.severity_score || 0) - Number(oldest.severity_score || 0)).toFixed(3));
   const highDelta = Number((Number(latest.failing_check_severity?.high || 0) - Number(oldest.failing_check_severity?.high || 0)).toFixed(3));
 
@@ -1760,6 +1786,22 @@ function buildMeetingPrepQualityDriftSignals({ oldest, latest }) {
       message: `Cross-owner dependency signoff coverage dropped by ${Math.abs(crossOwnerDependencySignoffCoverageDelta)} pct vs oldest snapshot.`,
     });
   }
+  if (closeReadinessGateMatrixCoverageDelta <= -5) {
+    signals.push({
+      code: 'close_readiness_gate_matrix_coverage_drop',
+      severity: closeReadinessGateMatrixCoverageDelta <= -30 ? 'high' : closeReadinessGateMatrixCoverageDelta <= -15 ? 'medium' : 'low',
+      delta: closeReadinessGateMatrixCoverageDelta,
+      message: `Close-readiness gate matrix coverage dropped by ${Math.abs(closeReadinessGateMatrixCoverageDelta)} pct vs oldest snapshot.`,
+    });
+  }
+  if (stakeholderSignoffEscalationLadderCoverageDelta <= -5) {
+    signals.push({
+      code: 'stakeholder_signoff_escalation_ladder_coverage_drop',
+      severity: stakeholderSignoffEscalationLadderCoverageDelta <= -30 ? 'high' : stakeholderSignoffEscalationLadderCoverageDelta <= -15 ? 'medium' : 'low',
+      delta: stakeholderSignoffEscalationLadderCoverageDelta,
+      message: `Stakeholder signoff escalation-ladder coverage dropped by ${Math.abs(stakeholderSignoffEscalationLadderCoverageDelta)} pct vs oldest snapshot.`,
+    });
+  }
 
   return signals;
 }
@@ -1809,6 +1851,8 @@ function buildMeetingPrepQualityEscalationLanes(latestSnapshot) {
   const stakeholderObjectionHandoffCoverage = Number(latestSnapshot.stakeholder_objection_handoff_coverage_pct || 0);
   const riskWeightedClosePlanSequencingCoverage = Number(latestSnapshot.risk_weighted_close_plan_sequencing_coverage_pct || 0);
   const crossOwnerDependencySignoffCoverage = Number(latestSnapshot.cross_owner_dependency_signoff_coverage_pct || 0);
+  const closeReadinessGateMatrixCoverage = Number(latestSnapshot.close_readiness_gate_matrix_coverage_pct || 0);
+  const stakeholderSignoffEscalationLadderCoverage = Number(latestSnapshot.stakeholder_signoff_escalation_ladder_coverage_pct || 0);
   if (narrativeCoverage < 80) {
     lanes.push({
       lane: 'stakeholder_narrative_pack_remediation',
@@ -1903,6 +1947,22 @@ function buildMeetingPrepQualityEscalationLanes(latestSnapshot) {
       severity: crossOwnerDependencySignoffCoverage < 60 ? 'high' : 'medium',
       trigger_count: Number(latestSnapshot.scored_meetings || 0) - Number(latestSnapshot.cross_owner_dependency_signoff_covered_count || 0),
       message: 'Cross-owner dependency signoff coverage is below target; require explicit primary/backup owner confirmation before closeout.',
+    });
+  }
+  if (closeReadinessGateMatrixCoverage < 80) {
+    lanes.push({
+      lane: 'close_readiness_gate_matrix_remediation',
+      severity: closeReadinessGateMatrixCoverage < 60 ? 'high' : 'medium',
+      trigger_count: Number(latestSnapshot.scored_meetings || 0) - Number(latestSnapshot.close_readiness_gate_matrix_covered_count || 0),
+      message: 'Close-readiness gate matrix coverage is below target; require deterministic close gate owner/action remediation before handoff.',
+    });
+  }
+  if (stakeholderSignoffEscalationLadderCoverage < 80) {
+    lanes.push({
+      lane: 'stakeholder_signoff_escalation_ladder_remediation',
+      severity: stakeholderSignoffEscalationLadderCoverage < 60 ? 'high' : 'medium',
+      trigger_count: Number(latestSnapshot.scored_meetings || 0) - Number(latestSnapshot.stakeholder_signoff_escalation_ladder_covered_count || 0),
+      message: 'Stakeholder signoff escalation-ladder coverage is below target; require explicit escalation-owner/SLA routing before closeout.',
     });
   }
 
@@ -2018,6 +2078,37 @@ function hasCrossOwnerDependencySignoffPack(pack) {
     const signoffQuestion = String(row?.signoffQuestion || '').trim();
     const dueWindow = String(row?.dueWindow || '').trim();
     return dependency.length > 0 && primaryOwner.length > 0 && backupOwner.length > 0 && signoffQuestion.length > 0 && dueWindow.length > 0;
+  });
+}
+
+function hasCloseReadinessGateMatrix(matrix) {
+  if (!matrix || typeof matrix !== 'object') return false;
+  const summary = String(matrix?.summary || '').trim();
+  const gates = Array.isArray(matrix?.gates)
+    ? matrix.gates.filter((gate) => {
+      const name = String(gate?.gate || '').trim();
+      const status = String(gate?.status || '').trim();
+      const owner = String(gate?.ownerHint || '').trim();
+      const action = String(gate?.recommendedAction || '').trim();
+      return name.length > 0 && status.length > 0 && owner.length > 0 && action.length > 0;
+    })
+    : [];
+  return summary.length > 0 && gates.length > 0;
+}
+
+function hasStakeholderSignoffEscalationLadder(rows) {
+  if (!Array.isArray(rows) || !rows.length) return false;
+  return rows.some((row) => {
+    const trigger = String(row?.trigger || '').trim();
+    const prompt = String(row?.escalationPrompt || '').trim();
+    const primaryOwner = String(row?.primaryOwner || '').trim();
+    const escalationOwner = String(row?.escalationOwner || '').trim();
+    const slaWindow = String(row?.slaWindow || '').trim();
+    return trigger.length > 0
+      && prompt.length > 0
+      && primaryOwner.length > 0
+      && escalationOwner.length > 0
+      && slaWindow.length > 0;
   });
 }
 
@@ -2351,6 +2442,8 @@ function evaluateThresholdBreaches({ sources, failures, reconciliation, baseline
     || thresholds.min_quality_stakeholder_objection_handoff_coverage_pct !== null
     || thresholds.min_quality_risk_weighted_close_plan_sequencing_coverage_pct !== null
     || thresholds.min_quality_cross_owner_dependency_signoff_coverage_pct !== null
+    || thresholds.min_quality_close_readiness_gate_matrix_coverage_pct !== null
+    || thresholds.min_quality_stakeholder_signoff_escalation_ladder_coverage_pct !== null
   ) {
     if (!meetingPrepQuality?.available) {
       breaches.push({
@@ -2528,6 +2621,26 @@ function evaluateThresholdBreaches({ sources, failures, reconciliation, baseline
             kind: 'quality_cross_owner_dependency_signoff_coverage_pct',
             actual: latestCrossOwnerDependencySignoffCoverage,
             limit: thresholds.min_quality_cross_owner_dependency_signoff_coverage_pct,
+          });
+        }
+      }
+      if (thresholds.min_quality_close_readiness_gate_matrix_coverage_pct !== null) {
+        const latestCloseReadinessGateMatrixCoverage = Number(meetingPrepQuality?.latest?.close_readiness_gate_matrix_coverage_pct || 0);
+        if (latestCloseReadinessGateMatrixCoverage < thresholds.min_quality_close_readiness_gate_matrix_coverage_pct) {
+          breaches.push({
+            kind: 'quality_close_readiness_gate_matrix_coverage_pct',
+            actual: latestCloseReadinessGateMatrixCoverage,
+            limit: thresholds.min_quality_close_readiness_gate_matrix_coverage_pct,
+          });
+        }
+      }
+      if (thresholds.min_quality_stakeholder_signoff_escalation_ladder_coverage_pct !== null) {
+        const latestStakeholderSignoffEscalationLadderCoverage = Number(meetingPrepQuality?.latest?.stakeholder_signoff_escalation_ladder_coverage_pct || 0);
+        if (latestStakeholderSignoffEscalationLadderCoverage < thresholds.min_quality_stakeholder_signoff_escalation_ladder_coverage_pct) {
+          breaches.push({
+            kind: 'quality_stakeholder_signoff_escalation_ladder_coverage_pct',
+            actual: latestStakeholderSignoffEscalationLadderCoverage,
+            limit: thresholds.min_quality_stakeholder_signoff_escalation_ladder_coverage_pct,
           });
         }
       }
@@ -2815,7 +2928,7 @@ function severityForBreachKind(kind) {
   if (['lag_hours', 'seen_drift_hours', 'baseline_anomalies_count', 'reconciliation_unavailable', 'slo_budget_unavailable', 'slo_budget_burn_pct', 'meeting_prep_quality_unavailable', 'quality_severity_score', 'quality_readiness_drop', 'quality_confidence_calibration_drop'].includes(k)) {
     return 'high';
   }
-  if (['entity_delta_pct', 'chunk_ratio_delta', 'link_delta_pct', 'artifact_issues_count', 'quality_drift_signals_count', 'quality_narrative_coverage_pct', 'quality_dependency_coverage_pct', 'quality_decision_sequencing_coverage_pct', 'quality_close_scripts_coverage_pct', 'quality_failure_mode_rehearsal_coverage_pct', 'quality_stakeholder_proof_request_coverage_pct', 'quality_owner_assignment_coverage_pct', 'quality_counterfactual_decision_drill_coverage_pct', 'quality_stakeholder_objection_handoff_coverage_pct', 'quality_risk_weighted_close_plan_sequencing_coverage_pct', 'quality_cross_owner_dependency_signoff_coverage_pct'].includes(k)) {
+  if (['entity_delta_pct', 'chunk_ratio_delta', 'link_delta_pct', 'artifact_issues_count', 'quality_drift_signals_count', 'quality_narrative_coverage_pct', 'quality_dependency_coverage_pct', 'quality_decision_sequencing_coverage_pct', 'quality_close_scripts_coverage_pct', 'quality_failure_mode_rehearsal_coverage_pct', 'quality_stakeholder_proof_request_coverage_pct', 'quality_owner_assignment_coverage_pct', 'quality_counterfactual_decision_drill_coverage_pct', 'quality_stakeholder_objection_handoff_coverage_pct', 'quality_risk_weighted_close_plan_sequencing_coverage_pct', 'quality_cross_owner_dependency_signoff_coverage_pct', 'quality_close_readiness_gate_matrix_coverage_pct', 'quality_stakeholder_signoff_escalation_ladder_coverage_pct'].includes(k)) {
     return 'medium';
   }
   return 'low';
@@ -2992,7 +3105,7 @@ function buildTrendArtifactMarkdown(payload) {
   } else {
     lines.push(`- scanned_artifacts=${prep.scanned_artifacts ?? 0}, snapshots=${prep.snapshots ?? 0}, meetings_scored=${prep.meetings_scored ?? 0}`);
     lines.push(`- latest_avg_score=${formatNumber(prep.latest?.avg_score)}, latest_avg_gap_count=${formatNumber(prep.latest?.avg_gap_count)}, latest_severity_score=${formatNumber(prep.latest?.severity_score)}`);
-    lines.push(`- latest_readiness_score=${formatNumber(prep.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(prep.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(prep.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(prep.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(prep.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(prep.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(prep.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(prep.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(prep.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(prep.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(prep.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(prep.latest?.stakeholder_objection_handoff_coverage_pct)}, latest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(prep.latest?.risk_weighted_close_plan_sequencing_coverage_pct)}, latest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(prep.latest?.cross_owner_dependency_signoff_coverage_pct)}`);
+    lines.push(`- latest_readiness_score=${formatNumber(prep.latest?.readiness_score)}, latest_narrative_coverage_pct=${formatNumber(prep.latest?.narrative_coverage_pct)}, latest_dependency_coverage_pct=${formatNumber(prep.latest?.dependency_coverage_pct)}, latest_decision_sequencing_coverage_pct=${formatNumber(prep.latest?.decision_sequencing_coverage_pct)}, latest_close_scripts_coverage_pct=${formatNumber(prep.latest?.close_scripts_coverage_pct)}, latest_failure_mode_rehearsal_coverage_pct=${formatNumber(prep.latest?.failure_mode_rehearsal_coverage_pct)}, latest_stakeholder_proof_request_coverage_pct=${formatNumber(prep.latest?.stakeholder_proof_request_coverage_pct)}, latest_confidence_calibration_coverage_pct=${formatNumber(prep.latest?.confidence_calibration_coverage_pct)}, latest_confidence_calibration_avg_delta=${formatNumber(prep.latest?.confidence_calibration_avg_delta)}, latest_owner_assignment_coverage_pct=${formatNumber(prep.latest?.owner_assignment_coverage_pct)}, latest_counterfactual_decision_drill_coverage_pct=${formatNumber(prep.latest?.counterfactual_decision_drill_coverage_pct)}, latest_stakeholder_objection_handoff_coverage_pct=${formatNumber(prep.latest?.stakeholder_objection_handoff_coverage_pct)}, latest_risk_weighted_close_plan_sequencing_coverage_pct=${formatNumber(prep.latest?.risk_weighted_close_plan_sequencing_coverage_pct)}, latest_cross_owner_dependency_signoff_coverage_pct=${formatNumber(prep.latest?.cross_owner_dependency_signoff_coverage_pct)}, latest_close_readiness_gate_matrix_coverage_pct=${formatNumber(prep.latest?.close_readiness_gate_matrix_coverage_pct)}, latest_stakeholder_signoff_escalation_ladder_coverage_pct=${formatNumber(prep.latest?.stakeholder_signoff_escalation_ladder_coverage_pct)}`);
     const driftSignals = Array.isArray(prep.drift_signals) ? prep.drift_signals : [];
     if (!driftSignals.length) {
       lines.push('- drift_signals=none');


### PR DESCRIPTION
## Summary\n- add phase-16 meeting-prep quality snapshot metrics for close-readiness gate matrix and stakeholder signoff escalation ladder coverage\n- add phase-16 drift signals, remediation lanes, and optional threshold breach gates\n- document new health flags/metrics in db and deploy runbooks\n\n## Validation\n- node --check scripts/db/hybrid-ingestion-health.mjs\n- npm run db:hybrid:init\n- npm run db:hybrid:health\n- npm run db:hybrid:health -- --json --max-quality-drift-signals 999 --max-quality-severity-score 999 --min-quality-close-readiness-gate-matrix-coverage-pct 0 --min-quality-stakeholder-signoff-escalation-ladder-coverage-pct 0\n- npm run db:hybrid:health -- --json --min-quality-close-readiness-gate-matrix-coverage-pct 101 (expected exit code 2)\n- npm run md:audit:strict\n\nCloses #181