### PR TITLE
feat(ci): wire phase-16 quality breaches into alert routing + ACK defaults

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -225,6 +225,10 @@ jobs:
               quality_cross_owner_dependency_signoff_breach_count: "0",
               quality_phase15_top_breach_kind: "",
               quality_phase15_gate_breached: "false",
+              quality_close_readiness_gate_matrix_breach_count: "0",
+              quality_stakeholder_signoff_escalation_ladder_breach_count: "0",
+              quality_phase16_top_breach_kind: "",
+              quality_phase16_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -267,12 +271,16 @@ jobs:
             const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
             const riskWeightedClosePlanSequencingBreachCount = breaches.filter((b) => b?.kind === "quality_risk_weighted_close_plan_sequencing_coverage_pct").length;
             const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
+            const closeReadinessGateMatrixBreachCount = breaches.filter((b) => b?.kind === "quality_close_readiness_gate_matrix_coverage_pct").length;
+            const stakeholderSignoffEscalationLadderBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_signoff_escalation_ladder_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
+            const qualityPhase16GateBreached = closeReadinessGateMatrixBreachCount > 0 || stakeholderSignoffEscalationLadderBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
               || qualityPhase15GateBreached
+              || qualityPhase16GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -292,6 +300,10 @@ jobs:
               riskWeightedClosePlanSequencingBreachCount >= crossOwnerDependencySignoffBreachCount
                 ? (riskWeightedClosePlanSequencingBreachCount > 0 ? "quality_risk_weighted_close_plan_sequencing_coverage_pct" : "")
                 : "quality_cross_owner_dependency_signoff_coverage_pct";
+            const qualityPhase16TopBreachKind =
+              closeReadinessGateMatrixBreachCount >= stakeholderSignoffEscalationLadderBreachCount
+                ? (closeReadinessGateMatrixBreachCount > 0 ? "quality_close_readiness_gate_matrix_coverage_pct" : "")
+                : "quality_stakeholder_signoff_escalation_ladder_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -308,6 +320,10 @@ jobs:
               quality_cross_owner_dependency_signoff_breach_count: String(crossOwnerDependencySignoffBreachCount),
               quality_phase15_top_breach_kind: qualityPhase15TopBreachKind,
               quality_phase15_gate_breached: qualityPhase15GateBreached ? "true" : "false",
+              quality_close_readiness_gate_matrix_breach_count: String(closeReadinessGateMatrixBreachCount),
+              quality_stakeholder_signoff_escalation_ladder_breach_count: String(stakeholderSignoffEscalationLadderBreachCount),
+              quality_phase16_top_breach_kind: qualityPhase16TopBreachKind,
+              quality_phase16_gate_breached: qualityPhase16GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -400,6 +416,10 @@ jobs:
           ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_cross_owner_dependency_signoff_breach_count }}
           ALERT_QUALITY_PHASE15_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase15_top_breach_kind }}
           ALERT_QUALITY_PHASE15_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase15_gate_breached }}
+          ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT: ${{ steps.quality.outputs.quality_close_readiness_gate_matrix_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_signoff_escalation_ladder_breach_count }}
+          ALERT_QUALITY_PHASE16_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase16_top_breach_kind }}
+          ALERT_QUALITY_PHASE16_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase16_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
@@ -656,6 +676,10 @@ jobs:
               quality_cross_owner_dependency_signoff_breach_count: "0",
               quality_phase15_top_breach_kind: "",
               quality_phase15_gate_breached: "false",
+              quality_close_readiness_gate_matrix_breach_count: "0",
+              quality_stakeholder_signoff_escalation_ladder_breach_count: "0",
+              quality_phase16_top_breach_kind: "",
+              quality_phase16_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -698,12 +722,16 @@ jobs:
             const stakeholderObjectionHandoffBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_objection_handoff_coverage_pct").length;
             const riskWeightedClosePlanSequencingBreachCount = breaches.filter((b) => b?.kind === "quality_risk_weighted_close_plan_sequencing_coverage_pct").length;
             const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
+            const closeReadinessGateMatrixBreachCount = breaches.filter((b) => b?.kind === "quality_close_readiness_gate_matrix_coverage_pct").length;
+            const stakeholderSignoffEscalationLadderBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_signoff_escalation_ladder_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
+            const qualityPhase16GateBreached = closeReadinessGateMatrixBreachCount > 0 || stakeholderSignoffEscalationLadderBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
               || qualityPhase15GateBreached
+              || qualityPhase16GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -723,6 +751,10 @@ jobs:
               riskWeightedClosePlanSequencingBreachCount >= crossOwnerDependencySignoffBreachCount
                 ? (riskWeightedClosePlanSequencingBreachCount > 0 ? "quality_risk_weighted_close_plan_sequencing_coverage_pct" : "")
                 : "quality_cross_owner_dependency_signoff_coverage_pct";
+            const qualityPhase16TopBreachKind =
+              closeReadinessGateMatrixBreachCount >= stakeholderSignoffEscalationLadderBreachCount
+                ? (closeReadinessGateMatrixBreachCount > 0 ? "quality_close_readiness_gate_matrix_coverage_pct" : "")
+                : "quality_stakeholder_signoff_escalation_ladder_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -739,6 +771,10 @@ jobs:
               quality_cross_owner_dependency_signoff_breach_count: String(crossOwnerDependencySignoffBreachCount),
               quality_phase15_top_breach_kind: qualityPhase15TopBreachKind,
               quality_phase15_gate_breached: qualityPhase15GateBreached ? "true" : "false",
+              quality_close_readiness_gate_matrix_breach_count: String(closeReadinessGateMatrixBreachCount),
+              quality_stakeholder_signoff_escalation_ladder_breach_count: String(stakeholderSignoffEscalationLadderBreachCount),
+              quality_phase16_top_breach_kind: qualityPhase16TopBreachKind,
+              quality_phase16_gate_breached: qualityPhase16GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -927,6 +963,10 @@ jobs:
           ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT: ${{ steps.quality.outputs.quality_cross_owner_dependency_signoff_breach_count }}
           ALERT_QUALITY_PHASE15_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase15_top_breach_kind }}
           ALERT_QUALITY_PHASE15_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase15_gate_breached }}
+          ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT: ${{ steps.quality.outputs.quality_close_readiness_gate_matrix_breach_count }}
+          ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_signoff_escalation_ladder_breach_count }}
+          ALERT_QUALITY_PHASE16_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase16_top_breach_kind }}
+          ALERT_QUALITY_PHASE16_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase16_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}

--- a/db/README.md
+++ b/db/README.md
@@ -335,7 +335,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -412,6 +412,10 @@ Runtime notes:
       - `quality_counterfactual_decision_drill_breach_count`
       - `quality_stakeholder_objection_handoff_breach_count`
       - `quality_phase14_top_breach_kind`
+      - `quality_phase16_gate_breached`
+      - `quality_close_readiness_gate_matrix_breach_count`
+      - `quality_stakeholder_signoff_escalation_ladder_breach_count`
+      - `quality_phase16_top_breach_kind`
       - `quality_phase15_gate_breached`
       - `quality_risk_weighted_close_plan_sequencing_breach_count`
       - `quality_cross_owner_dependency_signoff_breach_count`

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -313,7 +313,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -373,6 +373,7 @@ Include:
       - quality drift metadata (`quality_drift_signal_count`, `quality_severity_score`, `quality_gate_breached`, `quality_top_lane`, `quality_top_lane_severity`)
       - phase-14 quality breach metadata (`quality_phase14_gate_breached`, `quality_counterfactual_decision_drill_breach_count`, `quality_stakeholder_objection_handoff_breach_count`, `quality_phase14_top_breach_kind`)
       - phase-15 quality breach metadata (`quality_phase15_gate_breached`, `quality_risk_weighted_close_plan_sequencing_breach_count`, `quality_cross_owner_dependency_signoff_breach_count`, `quality_phase15_top_breach_kind`)
+      - phase-16 quality breach metadata (`quality_phase16_gate_breached`, `quality_close_readiness_gate_matrix_breach_count`, `quality_stakeholder_signoff_escalation_ladder_breach_count`, `quality_phase16_top_breach_kind`)
       - phase-13 quality breach metadata (`quality_phase13_gate_breached`, `quality_confidence_calibration_breach_count`, `quality_owner_assignment_breach_count`, `quality_phase13_top_breach_kind`)
       - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -197,6 +197,7 @@ function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualityPhase16GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED);
   const qualityPhase15GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED);
   const qualityPhase14GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED);
   const qualityPhase12GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED);
@@ -205,6 +206,9 @@ function classifyIncident() {
   const qualityPhase15BreachCount =
     Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || "0");
+  const qualityPhase16BreachCount =
+    Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || "0");
   const qualityPhase14BreachCount =
     Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || "0");
@@ -216,6 +220,9 @@ function classifyIncident() {
     + Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase16GateBreached) {
+    return { type: "quality_phase16_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityPhase15GateBreached) {
     return { type: "quality_phase15_gate_breach", drift_related: false, quality_related: true, severity: "high" };
@@ -234,6 +241,9 @@ function classifyIncident() {
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase16BreachCount) && qualityPhase16BreachCount > 0) {
+    return { type: "quality_phase16_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualityPhase15BreachCount) && qualityPhase15BreachCount > 0) {
     return { type: "quality_phase15_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -293,7 +303,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
-  } else if (incident.type === "quality_phase15_gate_breach" || incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
+  } else if (incident.type === "quality_phase16_gate_breach" || incident.type === "quality_phase15_gate_breach" || incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
@@ -305,7 +315,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
-  } else if (incident.type === "quality_phase15_signal_detected" || incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
+  } else if (incident.type === "quality_phase16_signal_detected" || incident.type === "quality_phase15_signal_detected" || incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
     defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
@@ -756,6 +766,11 @@ function buildAlertText({
   const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
   const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
   const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityPhase16GateBreached = process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED || "";
+  const qualityCloseReadinessGateMatrixBreachCount = process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || "";
+  const qualityStakeholderSignoffEscalationLadderBreachCount =
+    process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || "";
+  const qualityPhase16TopBreachKind = process.env.ALERT_QUALITY_PHASE16_TOP_BREACH_KIND || "";
   const qualityPhase15GateBreached = process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED || "";
   const qualityRiskWeightedClosePlanSequencingBreachCount = process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || "";
   const qualityCrossOwnerDependencySignoffBreachCount = process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || "";
@@ -820,6 +835,10 @@ function buildAlertText({
     qualitySignals ||
     qualitySeverityScore ||
     qualityGateBreached ||
+    qualityPhase16GateBreached ||
+    qualityCloseReadinessGateMatrixBreachCount ||
+    qualityStakeholderSignoffEscalationLadderBreachCount ||
+    qualityPhase16TopBreachKind ||
     qualityPhase15GateBreached ||
     qualityRiskWeightedClosePlanSequencingBreachCount ||
     qualityCrossOwnerDependencySignoffBreachCount ||
@@ -842,6 +861,9 @@ function buildAlertText({
   ) {
     lines.push(
       `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
+    lines.push(
+      `Meeting-prep quality phase16: gateBreached=${qualityPhase16GateBreached || "n/a"}, closeReadinessGateMatrixBreaches=${qualityCloseReadinessGateMatrixBreachCount || "0"}, stakeholderSignoffEscalationLadderBreaches=${qualityStakeholderSignoffEscalationLadderBreachCount || "0"}, phase16TopBreachKind=${qualityPhase16TopBreachKind || "n/a"}`
     );
     lines.push(
       `Meeting-prep quality phase15: gateBreached=${qualityPhase15GateBreached || "n/a"}, riskWeightedClosePlanSequencingBreaches=${qualityRiskWeightedClosePlanSequencingBreachCount || "0"}, crossOwnerDependencySignoffBreaches=${qualityCrossOwnerDependencySignoffBreachCount || "0"}, phase15TopBreachKind=${qualityPhase15TopBreachKind || "n/a"}`
@@ -1158,10 +1180,14 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase16_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED),
       quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
       quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
       quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
       quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_close_readiness_gate_matrix_breach_count: Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || 0),
+      quality_stakeholder_signoff_escalation_ladder_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || 0),
+      quality_phase16_top_breach_kind: process.env.ALERT_QUALITY_PHASE16_TOP_BREACH_KIND || null,
       quality_risk_weighted_close_plan_sequencing_breach_count: Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || 0),
       quality_cross_owner_dependency_signoff_breach_count: Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || 0),
       quality_phase15_top_breach_kind: process.env.ALERT_QUALITY_PHASE15_TOP_BREACH_KIND || null,
@@ -1231,10 +1257,14 @@ async function main() {
     quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
     quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
     quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase16_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED),
     quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
     quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
     quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
     quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_close_readiness_gate_matrix_breach_count: Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || 0),
+    quality_stakeholder_signoff_escalation_ladder_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || 0),
+    quality_phase16_top_breach_kind: process.env.ALERT_QUALITY_PHASE16_TOP_BREACH_KIND || null,
     quality_risk_weighted_close_plan_sequencing_breach_count: Number(process.env.ALERT_QUALITY_RISK_WEIGHTED_CLOSE_PLAN_SEQUENCING_BREACH_COUNT || 0),
     quality_cross_owner_dependency_signoff_breach_count: Number(process.env.ALERT_QUALITY_CROSS_OWNER_DEPENDENCY_SIGNOFF_BREACH_COUNT || 0),
     quality_phase15_top_breach_kind: process.env.ALERT_QUALITY_PHASE15_TOP_BREACH_KIND || null,


### PR DESCRIPTION
## Summary
- add phase-16 quality extraction outputs in hybrid daily workflow (canary + live)
- route phase-16 metadata into alert dispatch environment variables
- extend `dispatch-hybrid-alert.mjs` for phase-16 incident classification and ACK policy parity
- include phase-16 breach metadata in alert text, payload metadata, and summary JSON
- document phase-16 incident types/fields in operator runbooks

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/hybrid-daily-pipeline.yml'); puts 'yaml-ok'"`
- `ALERT_DRY_RUN=1 ... node scripts/ci/dispatch-hybrid-alert.mjs` (confirmed `incident_type=quality_phase16_gate_breach`)
- `npm run md:audit:strict`

Closes #184