### PR TITLE
feat(ci): live ops phase 17 readiness-cadence alert parity

### DIFF
--- a/.github/workflows/hybrid-daily-pipeline.yml
+++ b/.github/workflows/hybrid-daily-pipeline.yml
@@ -229,6 +229,10 @@ jobs:
               quality_stakeholder_signoff_escalation_ladder_breach_count: "0",
               quality_phase16_top_breach_kind: "",
               quality_phase16_gate_breached: "false",
+              quality_readiness_cadence_contract_pack_breach_count: "0",
+              quality_readiness_cadence_high_priority_breach_count: "0",
+              quality_phase17_top_breach_kind: "",
+              quality_phase17_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -273,14 +277,18 @@ jobs:
             const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
             const closeReadinessGateMatrixBreachCount = breaches.filter((b) => b?.kind === "quality_close_readiness_gate_matrix_coverage_pct").length;
             const stakeholderSignoffEscalationLadderBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_signoff_escalation_ladder_coverage_pct").length;
+            const readinessCadenceContractPackBreachCount = breaches.filter((b) => b?.kind === "quality_readiness_cadence_contract_pack_coverage_pct").length;
+            const readinessCadenceHighPriorityBreachCount = breaches.filter((b) => b?.kind === "quality_readiness_cadence_high_priority_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
             const qualityPhase16GateBreached = closeReadinessGateMatrixBreachCount > 0 || stakeholderSignoffEscalationLadderBreachCount > 0;
+            const qualityPhase17GateBreached = readinessCadenceContractPackBreachCount > 0 || readinessCadenceHighPriorityBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
               || qualityPhase15GateBreached
               || qualityPhase16GateBreached
+              || qualityPhase17GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -304,6 +312,10 @@ jobs:
               closeReadinessGateMatrixBreachCount >= stakeholderSignoffEscalationLadderBreachCount
                 ? (closeReadinessGateMatrixBreachCount > 0 ? "quality_close_readiness_gate_matrix_coverage_pct" : "")
                 : "quality_stakeholder_signoff_escalation_ladder_coverage_pct";
+            const qualityPhase17TopBreachKind =
+              readinessCadenceContractPackBreachCount >= readinessCadenceHighPriorityBreachCount
+                ? (readinessCadenceContractPackBreachCount > 0 ? "quality_readiness_cadence_contract_pack_coverage_pct" : "")
+                : "quality_readiness_cadence_high_priority_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -324,6 +336,10 @@ jobs:
               quality_stakeholder_signoff_escalation_ladder_breach_count: String(stakeholderSignoffEscalationLadderBreachCount),
               quality_phase16_top_breach_kind: qualityPhase16TopBreachKind,
               quality_phase16_gate_breached: qualityPhase16GateBreached ? "true" : "false",
+              quality_readiness_cadence_contract_pack_breach_count: String(readinessCadenceContractPackBreachCount),
+              quality_readiness_cadence_high_priority_breach_count: String(readinessCadenceHighPriorityBreachCount),
+              quality_phase17_top_breach_kind: qualityPhase17TopBreachKind,
+              quality_phase17_gate_breached: qualityPhase17GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -420,6 +436,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_signoff_escalation_ladder_breach_count }}
           ALERT_QUALITY_PHASE16_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase16_top_breach_kind }}
           ALERT_QUALITY_PHASE16_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase16_gate_breached }}
+          ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT: ${{ steps.quality.outputs.quality_readiness_cadence_contract_pack_breach_count }}
+          ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT: ${{ steps.quality.outputs.quality_readiness_cadence_high_priority_breach_count }}
+          ALERT_QUALITY_PHASE17_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase17_top_breach_kind }}
+          ALERT_QUALITY_PHASE17_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase17_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}
@@ -680,6 +700,10 @@ jobs:
               quality_stakeholder_signoff_escalation_ladder_breach_count: "0",
               quality_phase16_top_breach_kind: "",
               quality_phase16_gate_breached: "false",
+              quality_readiness_cadence_contract_pack_breach_count: "0",
+              quality_readiness_cadence_high_priority_breach_count: "0",
+              quality_phase17_top_breach_kind: "",
+              quality_phase17_gate_breached: "false",
               quality_phase12_top_breach_kind: "",
               quality_phase12_gate_breached: "false",
               quality_phase13_top_breach_kind: "",
@@ -724,14 +748,18 @@ jobs:
             const crossOwnerDependencySignoffBreachCount = breaches.filter((b) => b?.kind === "quality_cross_owner_dependency_signoff_coverage_pct").length;
             const closeReadinessGateMatrixBreachCount = breaches.filter((b) => b?.kind === "quality_close_readiness_gate_matrix_coverage_pct").length;
             const stakeholderSignoffEscalationLadderBreachCount = breaches.filter((b) => b?.kind === "quality_stakeholder_signoff_escalation_ladder_coverage_pct").length;
+            const readinessCadenceContractPackBreachCount = breaches.filter((b) => b?.kind === "quality_readiness_cadence_contract_pack_coverage_pct").length;
+            const readinessCadenceHighPriorityBreachCount = breaches.filter((b) => b?.kind === "quality_readiness_cadence_high_priority_coverage_pct").length;
             const qualityPhase14GateBreached = counterfactualDecisionDrillBreachCount > 0 || stakeholderObjectionHandoffBreachCount > 0;
             const qualityPhase15GateBreached = riskWeightedClosePlanSequencingBreachCount > 0 || crossOwnerDependencySignoffBreachCount > 0;
             const qualityPhase16GateBreached = closeReadinessGateMatrixBreachCount > 0 || stakeholderSignoffEscalationLadderBreachCount > 0;
+            const qualityPhase17GateBreached = readinessCadenceContractPackBreachCount > 0 || readinessCadenceHighPriorityBreachCount > 0;
             const qualityPhase12GateBreached = failureModeRehearsalBreachCount > 0 || stakeholderProofRequestBreachCount > 0;
             const qualityPhase13GateBreached = confidenceCalibrationBreachCount > 0 || ownerAssignmentBreachCount > 0;
             const qualityGateBreached = qualityPhase14GateBreached
               || qualityPhase15GateBreached
               || qualityPhase16GateBreached
+              || qualityPhase17GateBreached
               || qualityPhase12GateBreached
               || qualityPhase13GateBreached
               || breaches.some((b) => b?.kind === "quality_drift_signals_count" || b?.kind === "quality_severity_score");
@@ -755,6 +783,10 @@ jobs:
               closeReadinessGateMatrixBreachCount >= stakeholderSignoffEscalationLadderBreachCount
                 ? (closeReadinessGateMatrixBreachCount > 0 ? "quality_close_readiness_gate_matrix_coverage_pct" : "")
                 : "quality_stakeholder_signoff_escalation_ladder_coverage_pct";
+            const qualityPhase17TopBreachKind =
+              readinessCadenceContractPackBreachCount >= readinessCadenceHighPriorityBreachCount
+                ? (readinessCadenceContractPackBreachCount > 0 ? "quality_readiness_cadence_contract_pack_coverage_pct" : "")
+                : "quality_readiness_cadence_high_priority_coverage_pct";
 
             append({
               quality_signal_count: Number.isFinite(driftSignals) ? String(driftSignals) : "0",
@@ -775,6 +807,10 @@ jobs:
               quality_stakeholder_signoff_escalation_ladder_breach_count: String(stakeholderSignoffEscalationLadderBreachCount),
               quality_phase16_top_breach_kind: qualityPhase16TopBreachKind,
               quality_phase16_gate_breached: qualityPhase16GateBreached ? "true" : "false",
+              quality_readiness_cadence_contract_pack_breach_count: String(readinessCadenceContractPackBreachCount),
+              quality_readiness_cadence_high_priority_breach_count: String(readinessCadenceHighPriorityBreachCount),
+              quality_phase17_top_breach_kind: qualityPhase17TopBreachKind,
+              quality_phase17_gate_breached: qualityPhase17GateBreached ? "true" : "false",
               quality_phase12_top_breach_kind: qualityPhase12TopBreachKind,
               quality_phase12_gate_breached: qualityPhase12GateBreached ? "true" : "false",
               quality_phase13_top_breach_kind: qualityPhase13TopBreachKind,
@@ -967,6 +1003,10 @@ jobs:
           ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT: ${{ steps.quality.outputs.quality_stakeholder_signoff_escalation_ladder_breach_count }}
           ALERT_QUALITY_PHASE16_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase16_top_breach_kind }}
           ALERT_QUALITY_PHASE16_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase16_gate_breached }}
+          ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT: ${{ steps.quality.outputs.quality_readiness_cadence_contract_pack_breach_count }}
+          ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT: ${{ steps.quality.outputs.quality_readiness_cadence_high_priority_breach_count }}
+          ALERT_QUALITY_PHASE17_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase17_top_breach_kind }}
+          ALERT_QUALITY_PHASE17_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase17_gate_breached }}
           ALERT_QUALITY_PHASE12_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase12_top_breach_kind }}
           ALERT_QUALITY_PHASE12_GATE_BREACHED: ${{ steps.quality.outputs.quality_phase12_gate_breached }}
           ALERT_QUALITY_PHASE13_TOP_BREACH_KIND: ${{ steps.quality.outputs.quality_phase13_top_breach_kind }}

--- a/db/README.md
+++ b/db/README.md
@@ -338,7 +338,7 @@ Runtime notes:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach|quality_phase17_signal_detected|quality_phase17_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -419,6 +419,10 @@ Runtime notes:
       - `quality_close_readiness_gate_matrix_breach_count`
       - `quality_stakeholder_signoff_escalation_ladder_breach_count`
       - `quality_phase16_top_breach_kind`
+      - `quality_phase17_gate_breached`
+      - `quality_readiness_cadence_contract_pack_breach_count`
+      - `quality_readiness_cadence_high_priority_breach_count`
+      - `quality_phase17_top_breach_kind`
       - `quality_phase15_gate_breached`
       - `quality_risk_weighted_close_plan_sequencing_breach_count`
       - `quality_cross_owner_dependency_signoff_breach_count`
@@ -654,8 +658,8 @@ Output includes:
   - aggregates breach events by severity and source/top breach kinds
 - threshold metadata (`thresholds`) and explicit breach records (`breaches`)
 - meeting-prep quality trendline drift analysis from `artifacts/meeting-prep-quality-*.json` and `artifacts/meeting-prep-phase*.json`:
-  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`)
-  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`, `counterfactual_decision_drill_coverage_drop`, `stakeholder_objection_handoff_coverage_drop`, `risk_weighted_close_plan_sequencing_coverage_drop`, `cross_owner_dependency_signoff_coverage_drop`, `close_readiness_gate_matrix_coverage_drop`, `stakeholder_signoff_escalation_ladder_coverage_drop`)
+  - trendline snapshots (`avg_score`, `avg_gap_count`, failing-check severity score, `readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`, `readiness_cadence_contract_pack_coverage_pct`, `readiness_cadence_high_priority_coverage_pct`)
+  - deterministic drift signals (`quality_score_drop`, `quality_gap_growth`, `gap_severity_growth`, `high_severity_gap_growth`, `quality_readiness_drop`, `narrative_coverage_drop`, `dependency_coverage_drop`, `decision_sequencing_coverage_drop`, `close_scripts_coverage_drop`, `failure_mode_rehearsal_coverage_drop`, `stakeholder_proof_request_coverage_drop`, `confidence_calibration_coverage_drop`, `confidence_calibration_avg_delta_drop`, `owner_assignment_coverage_drop`, `counterfactual_decision_drill_coverage_drop`, `stakeholder_objection_handoff_coverage_drop`, `risk_weighted_close_plan_sequencing_coverage_drop`, `cross_owner_dependency_signoff_coverage_drop`, `close_readiness_gate_matrix_coverage_drop`, `stakeholder_signoff_escalation_ladder_coverage_drop`, `readiness_cadence_contract_pack_coverage_drop`, `readiness_cadence_high_priority_coverage_drop`)
   - deterministic escalation lanes by latest gap severity (`immediate_owner_escalation`, `same_day_quality_remediation`, `next_cycle_hardening`, `monitor_only`)
 - trend artifact export metadata (`trend_artifacts`) with written/pruned file paths when enabled
 - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned file paths when enabled

--- a/docs/RUNBOOK_DEPLOY_GENERIC.md
+++ b/docs/RUNBOOK_DEPLOY_GENERIC.md
@@ -314,7 +314,7 @@ Include:
       - `default`
       - `run_mode.<canary|live>`
       - `incident_severity.<medium|high>`
-      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach>`
+      - `incident_type.<health_gate_breach|drift_signal_detected|drift_gate_breach|quality_drift_signal_detected|quality_drift_gate_breach|quality_phase12_signal_detected|quality_phase12_gate_breach|quality_phase13_signal_detected|quality_phase13_gate_breach|quality_phase14_signal_detected|quality_phase14_gate_breach|quality_phase15_signal_detected|quality_phase15_gate_breach|quality_phase16_signal_detected|quality_phase16_gate_breach|quality_phase17_signal_detected|quality_phase17_gate_breach>`
       - `incident_age_band.<new|fresh|aging|critical>`
     - each node supports:
       - `ack_sla_minutes`
@@ -375,6 +375,7 @@ Include:
       - phase-14 quality breach metadata (`quality_phase14_gate_breached`, `quality_counterfactual_decision_drill_breach_count`, `quality_stakeholder_objection_handoff_breach_count`, `quality_phase14_top_breach_kind`)
       - phase-15 quality breach metadata (`quality_phase15_gate_breached`, `quality_risk_weighted_close_plan_sequencing_breach_count`, `quality_cross_owner_dependency_signoff_breach_count`, `quality_phase15_top_breach_kind`)
       - phase-16 quality breach metadata (`quality_phase16_gate_breached`, `quality_close_readiness_gate_matrix_breach_count`, `quality_stakeholder_signoff_escalation_ladder_breach_count`, `quality_phase16_top_breach_kind`)
+      - phase-17 quality breach metadata (`quality_phase17_gate_breached`, `quality_readiness_cadence_contract_pack_breach_count`, `quality_readiness_cadence_high_priority_breach_count`, `quality_phase17_top_breach_kind`)
       - phase-13 quality breach metadata (`quality_phase13_gate_breached`, `quality_confidence_calibration_breach_count`, `quality_owner_assignment_breach_count`, `quality_phase13_top_breach_kind`)
       - phase-12 quality breach metadata (`quality_phase12_gate_breached`, `quality_failure_mode_rehearsal_breach_count`, `quality_stakeholder_proof_request_breach_count`, `quality_phase12_top_breach_kind`)
       - ACK reconciliation/reminder metadata (`ack_reconciled`, `ack_reconciliation_source`, `ack_reminders_due_count`, `ack_reminder_escalations_due_count`)
@@ -515,7 +516,7 @@ Include:
   - meeting-prep quality trendline drift analysis:
     - scans `meeting-prep-quality-*.json` + `meeting-prep-phase*.json`
     - emits deterministic drift signals and severity-based escalation lanes
-    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`)
+    - includes readiness/coverage metrics (`readiness_score`, `narrative_coverage_pct`, `dependency_coverage_pct`, `decision_sequencing_coverage_pct`, `close_scripts_coverage_pct`, `failure_mode_rehearsal_coverage_pct`, `stakeholder_proof_request_coverage_pct`, `confidence_calibration_coverage_pct`, `confidence_calibration_avg_delta`, `owner_assignment_coverage_pct`, `counterfactual_decision_drill_coverage_pct`, `stakeholder_objection_handoff_coverage_pct`, `risk_weighted_close_plan_sequencing_coverage_pct`, `cross_owner_dependency_signoff_coverage_pct`, `close_readiness_gate_matrix_coverage_pct`, `stakeholder_signoff_escalation_ladder_coverage_pct`, `readiness_cadence_contract_pack_coverage_pct`, `readiness_cadence_high_priority_coverage_pct`)
   - trend artifact export metadata (`trend_artifacts`) with written/pruned files when export is enabled
   - weekly SLO digest artifact export metadata (`slo_digest_artifacts`) with written/pruned files when export is enabled
 

--- a/scripts/ci/dispatch-hybrid-alert.mjs
+++ b/scripts/ci/dispatch-hybrid-alert.mjs
@@ -197,6 +197,7 @@ function classifyIncident() {
   const driftGateBreached = toBoolean(process.env.ALERT_DRIFT_GATE_BREACHED);
   const driftSignalCount = Number(process.env.ALERT_DRIFT_SIGNAL_COUNT || "0");
   const qualityGateBreached = toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED);
+  const qualityPhase17GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE17_GATE_BREACHED);
   const qualityPhase16GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED);
   const qualityPhase15GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED);
   const qualityPhase14GateBreached = toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED);
@@ -209,6 +210,9 @@ function classifyIncident() {
   const qualityPhase16BreachCount =
     Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || "0");
+  const qualityPhase17BreachCount =
+    Number(process.env.ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT || "0")
+    + Number(process.env.ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT || "0");
   const qualityPhase14BreachCount =
     Number(process.env.ALERT_QUALITY_COUNTERFACTUAL_DECISION_DRILL_BREACH_COUNT || "0")
     + Number(process.env.ALERT_QUALITY_STAKEHOLDER_OBJECTION_HANDOFF_BREACH_COUNT || "0");
@@ -220,6 +224,9 @@ function classifyIncident() {
     + Number(process.env.ALERT_QUALITY_OWNER_ASSIGNMENT_BREACH_COUNT || "0");
   if (driftGateBreached) {
     return { type: "drift_gate_breach", drift_related: true, quality_related: false, severity: "high" };
+  }
+  if (qualityPhase17GateBreached) {
+    return { type: "quality_phase17_gate_breach", drift_related: false, quality_related: true, severity: "high" };
   }
   if (qualityPhase16GateBreached) {
     return { type: "quality_phase16_gate_breach", drift_related: false, quality_related: true, severity: "high" };
@@ -241,6 +248,9 @@ function classifyIncident() {
   }
   if (Number.isFinite(driftSignalCount) && driftSignalCount > 0) {
     return { type: "drift_signal_detected", drift_related: true, quality_related: false, severity: "medium" };
+  }
+  if (Number.isFinite(qualityPhase17BreachCount) && qualityPhase17BreachCount > 0) {
+    return { type: "quality_phase17_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
   }
   if (Number.isFinite(qualityPhase16BreachCount) && qualityPhase16BreachCount > 0) {
     return { type: "quality_phase16_signal_detected", drift_related: false, quality_related: true, severity: "medium" };
@@ -303,7 +313,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
-  } else if (incident.type === "quality_phase16_gate_breach" || incident.type === "quality_phase15_gate_breach" || incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
+  } else if (incident.type === "quality_phase17_gate_breach" || incident.type === "quality_phase16_gate_breach" || incident.type === "quality_phase15_gate_breach" || incident.type === "quality_phase14_gate_breach" || incident.type === "quality_phase13_gate_breach" || incident.type === "quality_phase12_gate_breach") {
     defaults.ack_sla_minutes = 15;
     defaults.ack_reminder_interval_minutes = 15;
     defaults.ack_escalate_after_reminders = 1;
@@ -315,7 +325,7 @@ function resolveAckPolicy({ incident, runMode, policyConfig }) {
     defaults.ack_sla_minutes = 20;
   } else if (incident.type === "drift_signal_detected") {
     defaults.ack_sla_minutes = 30;
-  } else if (incident.type === "quality_phase16_signal_detected" || incident.type === "quality_phase15_signal_detected" || incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
+  } else if (incident.type === "quality_phase17_signal_detected" || incident.type === "quality_phase16_signal_detected" || incident.type === "quality_phase15_signal_detected" || incident.type === "quality_phase14_signal_detected" || incident.type === "quality_phase13_signal_detected" || incident.type === "quality_phase12_signal_detected") {
     defaults.ack_sla_minutes = 25;
   } else if (incident.type === "quality_drift_signal_detected") {
     defaults.ack_sla_minutes = 35;
@@ -766,7 +776,13 @@ function buildAlertText({
   const qualitySignals = process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || "";
   const qualitySeverityScore = process.env.ALERT_QUALITY_SEVERITY_SCORE || "";
   const qualityGateBreached = process.env.ALERT_QUALITY_GATE_BREACHED || "";
+  const qualityPhase17GateBreached = process.env.ALERT_QUALITY_PHASE17_GATE_BREACHED || "";
   const qualityPhase16GateBreached = process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED || "";
+  const qualityReadinessCadenceContractPackBreachCount =
+    process.env.ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT || "";
+  const qualityReadinessCadenceHighPriorityBreachCount =
+    process.env.ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT || "";
+  const qualityPhase17TopBreachKind = process.env.ALERT_QUALITY_PHASE17_TOP_BREACH_KIND || "";
   const qualityCloseReadinessGateMatrixBreachCount = process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || "";
   const qualityStakeholderSignoffEscalationLadderBreachCount =
     process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || "";
@@ -835,6 +851,10 @@ function buildAlertText({
     qualitySignals ||
     qualitySeverityScore ||
     qualityGateBreached ||
+    qualityPhase17GateBreached ||
+    qualityReadinessCadenceContractPackBreachCount ||
+    qualityReadinessCadenceHighPriorityBreachCount ||
+    qualityPhase17TopBreachKind ||
     qualityPhase16GateBreached ||
     qualityCloseReadinessGateMatrixBreachCount ||
     qualityStakeholderSignoffEscalationLadderBreachCount ||
@@ -861,6 +881,9 @@ function buildAlertText({
   ) {
     lines.push(
       `Meeting-prep quality drift: signals=${qualitySignals || "n/a"}, severityScore=${qualitySeverityScore || "n/a"}, gateBreached=${qualityGateBreached || "n/a"}, phase12GateBreached=${qualityPhase12GateBreached || "n/a"}, failureModeRehearsalBreaches=${qualityFailureModeRehearsalBreachCount || "0"}, stakeholderProofRequestBreaches=${qualityStakeholderProofRequestBreachCount || "0"}, phase12TopBreachKind=${qualityPhase12TopBreachKind || "n/a"}, topLane=${qualityTopLane || "n/a"}, topLaneSeverity=${qualityTopLaneSeverity || "n/a"}`
+    );
+    lines.push(
+      `Meeting-prep quality phase17: gateBreached=${qualityPhase17GateBreached || "n/a"}, readinessCadenceContractPackBreaches=${qualityReadinessCadenceContractPackBreachCount || "0"}, readinessCadenceHighPriorityBreaches=${qualityReadinessCadenceHighPriorityBreachCount || "0"}, phase17TopBreachKind=${qualityPhase17TopBreachKind || "n/a"}`
     );
     lines.push(
       `Meeting-prep quality phase16: gateBreached=${qualityPhase16GateBreached || "n/a"}, closeReadinessGateMatrixBreaches=${qualityCloseReadinessGateMatrixBreachCount || "0"}, stakeholderSignoffEscalationLadderBreaches=${qualityStakeholderSignoffEscalationLadderBreachCount || "0"}, phase16TopBreachKind=${qualityPhase16TopBreachKind || "n/a"}`
@@ -1180,11 +1203,15 @@ async function main() {
       quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
       quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
       quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+      quality_phase17_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE17_GATE_BREACHED),
       quality_phase16_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED),
       quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
       quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
       quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
       quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+      quality_readiness_cadence_contract_pack_breach_count: Number(process.env.ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT || 0),
+      quality_readiness_cadence_high_priority_breach_count: Number(process.env.ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT || 0),
+      quality_phase17_top_breach_kind: process.env.ALERT_QUALITY_PHASE17_TOP_BREACH_KIND || null,
       quality_close_readiness_gate_matrix_breach_count: Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || 0),
       quality_stakeholder_signoff_escalation_ladder_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || 0),
       quality_phase16_top_breach_kind: process.env.ALERT_QUALITY_PHASE16_TOP_BREACH_KIND || null,
@@ -1257,11 +1284,15 @@ async function main() {
     quality_drift_signal_count: Number(process.env.ALERT_QUALITY_DRIFT_SIGNAL_COUNT || 0),
     quality_severity_score: Number(process.env.ALERT_QUALITY_SEVERITY_SCORE || 0),
     quality_gate_breached: toBoolean(process.env.ALERT_QUALITY_GATE_BREACHED),
+    quality_phase17_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE17_GATE_BREACHED),
     quality_phase16_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE16_GATE_BREACHED),
     quality_phase15_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE15_GATE_BREACHED),
     quality_phase14_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE14_GATE_BREACHED),
     quality_phase13_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE13_GATE_BREACHED),
     quality_phase12_gate_breached: toBoolean(process.env.ALERT_QUALITY_PHASE12_GATE_BREACHED),
+    quality_readiness_cadence_contract_pack_breach_count: Number(process.env.ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT || 0),
+    quality_readiness_cadence_high_priority_breach_count: Number(process.env.ALERT_QUALITY_READINESS_CADENCE_HIGH_PRIORITY_BREACH_COUNT || 0),
+    quality_phase17_top_breach_kind: process.env.ALERT_QUALITY_PHASE17_TOP_BREACH_KIND || null,
     quality_close_readiness_gate_matrix_breach_count: Number(process.env.ALERT_QUALITY_CLOSE_READINESS_GATE_MATRIX_BREACH_COUNT || 0),
     quality_stakeholder_signoff_escalation_ladder_breach_count: Number(process.env.ALERT_QUALITY_STAKEHOLDER_SIGNOFF_ESCALATION_LADDER_BREACH_COUNT || 0),
     quality_phase16_top_breach_kind: process.env.ALERT_QUALITY_PHASE16_TOP_BREACH_KIND || null,


### PR DESCRIPTION
## Summary
- wire phase-17 readiness-cadence breach extraction outputs in both canary/live quality metadata steps in `.github/workflows/hybrid-daily-pipeline.yml`
- propagate phase-17 quality env vars to alert dispatch (`ALERT_QUALITY_PHASE17_*`, readiness-cadence breach counts)
- extend `scripts/ci/dispatch-hybrid-alert.mjs` incident classification, ACK parity handling, alert text, and metadata contracts for phase 17
- update docs in `db/README.md` and `docs/RUNBOOK_DEPLOY_GENERIC.md` with new phase-17 incident types and metadata fields

## Validation
- `node --check scripts/ci/dispatch-hybrid-alert.mjs`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/hybrid-daily-pipeline.yml'); puts 'workflow_yaml_ok'"`
- dispatcher dry-run:\
  `ALERT_DRY_RUN=1 ... ALERT_QUALITY_PHASE17_GATE_BREACHED=true ALERT_QUALITY_READINESS_CADENCE_CONTRACT_PACK_BREACH_COUNT=1 node scripts/ci/dispatch-hybrid-alert.mjs`
- `npm run md:audit:strict`

Closes #193
